### PR TITLE
Examine page add affordance and tooltips to cols

### DIFF
--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -28,6 +28,52 @@ input {
 th#position input {
     width: 100px;
 }
+th.attr {
+    position: relative;
+}
+.tooltip {
+    display: none;
+    border-radius: 3px;
+    position: absolute;
+    top: 110%;
+    right: -63px;
+    background: white;
+    border: 1px solid #343434;
+    width: 250px;
+    font-size: 12px;
+    font-color: #3d3d3d;
+    z-index: 1000;
+}
+.tooltip p {
+    text-align: left;
+    padding: 2px 13px;
+}
+th.attr:hover .tooltip {
+    display: block;
+}
+.tooltip:after, .tooltip:before {
+    bottom: 100%;
+    left: 50%;
+    border: solid transparent;
+    content: " ";
+    height: 0;
+    width: 0;
+    position: absolute;
+    pointer-events: none;
+}
+.tooltip:after {
+    border-color: rgba(255, 255, 255, 0);
+    border-bottom-color: #ffffff;
+    border-width: 10px;
+    margin-left: -10px;
+}
+.tooltip:before {
+    border-color: rgba(52, 52, 52, 0);
+    border-bottom-color: #343434;
+    border-width: 11px;
+    margin-left: -11px;
+}
+
 select {
     padding: 13px 11px;
     width: 77px;

--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -31,12 +31,15 @@ th#position input {
 th.attr {
     position: relative;
 }
+th.attr > span {
+    border-bottom: 1px dashed #333;
+}
 .tooltip {
     display: none;
     border-radius: 3px;
     position: absolute;
     top: 110%;
-    right: -63px;
+    right: -72px;
     background: white;
     border: 1px solid #343434;
     width: 250px;
@@ -52,7 +55,7 @@ th.attr {
 .tooltip p strong {
     font-weight: bold;
 }
-th.attr:hover .tooltip {
+th.attr span:hover + .tooltip {
     display: block;
 }
 .tooltip:after, .tooltip:before {

--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -45,8 +45,12 @@ th.attr {
     z-index: 1000;
 }
 .tooltip p {
+    font-weight: 500;
     text-align: left;
     padding: 2px 13px;
+}
+.tooltip p strong {
+    font-weight: bold;
 }
 th.attr:hover .tooltip {
     display: block;

--- a/cycledash/static/js/examine/VCFTable.js
+++ b/cycledash/static/js/examine/VCFTable.js
@@ -31,12 +31,15 @@ var VCFTable = React.createClass({
      // relative positions -- slated to be removed soon. TODO(ihodes)
      karyogram: React.PropTypes.func.isRequired,
      // List of VCF records
-     records: React.PropTypes.arrayOf(React.PropTypes.object).isRequired
+     records: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
+     // The VCF header, used to get information about the INFO fields
+     header: React.PropTypes.object.isRequired
    },
    render: function() {
      return (
        <table>
          <VCFTableHeader attrs={this.props.attrs}
+                         header={this.props.header}
                          handleChartChange={this.props.handleChartChange} />
          <VCFTableFilter chromosomes={this.props.chromosomes}
                          handleFilterUpdate={this.props.handleFilterUpdate}
@@ -54,17 +57,33 @@ var VCFTable = React.createClass({
 
 var VCFTableHeader = React.createClass({
    propTypes: {
+     // The VCF header, used to get information about the INFO fields
+     header: React.PropTypes.object.isRequired,
      // Function which sends all the current filters up when a filter is changed
      handleChartChange: React.PropTypes.func.isRequired,
      // Array of attribute names from the INFO field of the VCF's records
-     attrs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+     attrs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired
    },
    handleChartToggle: function(e) {
-     this.props.handleChartChange(e.target.textContent);
+     var attribute = e.target.attributes.getNamedItem('data-attribute').value;
+     this.props.handleChartChange(attribute);
    },
    render: function() {
      var attrs = this.props.attrs.map(function(attr) {
-       return <th className="attr" key={attr} onClick={this.handleChartToggle}>{attr}</th>;
+       var info =  _.find(this.props.header.info, function(h) {
+         return h.ID === attr;
+       }),
+           infotext = info['Description'],
+           infoType = info[]
+       return (
+           <th className="attr" key={attr} onClick={this.handleChartToggle}
+               data-attribute={attr}>
+             <div className="tooltip" data-attribute={attr}>
+               <p>{infoText}</p>
+             </div>
+             {attr}
+           </th>
+       );
      }.bind(this));
      return (
        <thead>

--- a/cycledash/static/js/examine/VCFTable.js
+++ b/cycledash/static/js/examine/VCFTable.js
@@ -56,46 +56,59 @@ var VCFTable = React.createClass({
 });
 
 var VCFTableHeader = React.createClass({
-   propTypes: {
-     // The VCF header, used to get information about the INFO fields
-     header: React.PropTypes.object.isRequired,
-     // Function which sends all the current filters up when a filter is changed
-     handleChartChange: React.PropTypes.func.isRequired,
-     // Array of attribute names from the INFO field of the VCF's records
-     attrs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired
-   },
-   handleChartToggle: function(e) {
-     var attribute = e.target.attributes.getNamedItem('data-attribute').value;
-     this.props.handleChartChange(attribute);
-   },
-   render: function() {
-     var attrs = this.props.attrs.map(function(attr) {
-       var info =  _.find(this.props.header.info, function(h) {
-         return h.ID === attr;
-       }),
-           infotext = info['Description'],
-           infoType = info[]
-       return (
-           <th className="attr" key={attr} onClick={this.handleChartToggle}
-               data-attribute={attr}>
-             <div className="tooltip" data-attribute={attr}>
-               <p>{infoText}</p>
-             </div>
-             {attr}
-           </th>
-       );
-     }.bind(this));
-     return (
-       <thead>
-         <tr>
-           <th>Chromosome</th>
-           <th>Position</th>
-           <th>REF / ALT</th>
-           {attrs}
-         </tr>
-       </thead>
-     );
-   }
+  propTypes: {
+    // The VCF header, used to get information about the INFO fields
+    header: React.PropTypes.object.isRequired,
+    // Function which sends all the current filters up when a filter is changed
+    handleChartChange: React.PropTypes.func.isRequired,
+    // Array of attribute names from the INFO field of the VCF's records
+    attrs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired
+  },
+  handleChartToggle: function(e) {
+    var attribute = e.target.attributes.getNamedItem('data-attribute').value;
+    this.props.handleChartChange(attribute);
+  },
+  render: function() {
+    var attrs = this.props.attrs.map(function(attr) {
+      var info =  _.findWhere(this.props.header.info, {ID: attr});
+      return <InfoColumnTh info={info} attr={attr} key={attr} handleChartToggle={this.handleChartToggle} />;
+    }.bind(this));
+
+    return (
+      <thead>
+        <tr>
+          <th>Chromosome</th>
+          <th>Position</th>
+          <th>REF / ALT</th>
+          {attrs}
+        </tr>
+      </thead>
+    );
+  }
+});
+
+var InfoColumnTh = React.createClass({
+  render: function() {
+    return (
+      <th className="attr" onClick={this.props.handleChartToggle} data-attribute={this.props.attr}>
+        {this.props.attr}
+        <InfoColumnTooltip info={this.props.info} attr={this.props.attr} />
+      </th>
+    );
+  }
+});
+
+var InfoColumnTooltip = React.createClass({
+  render: function() {
+    var infoText = this.props.info['Description'],
+        infoType = this.props.info['Type'];
+    return (
+      <div className="tooltip" data-attribute={this.props.attr}>
+        <p className="description">{infoText}</p>
+        <p className="type">Type: <strong>{infoType}</strong></p>
+      </div>
+    );
+  }
 });
 
 var VCFTableFilter = React.createClass({

--- a/cycledash/static/js/examine/VCFTable.js
+++ b/cycledash/static/js/examine/VCFTable.js
@@ -88,6 +88,11 @@ var VCFTableHeader = React.createClass({
 });
 
 var InfoColumnTh = React.createClass({
+  propTypes: {
+    attr: React.PropTypes.string.isRequired,
+    info: React.PropTypes.object.isRequired,
+    handleChartToggle: React.PropTypes.func.isRequired
+  },
   render: function() {
     return (
       <th className="attr" onClick={this.props.handleChartToggle} data-attribute={this.props.attr}>
@@ -99,11 +104,15 @@ var InfoColumnTh = React.createClass({
 });
 
 var InfoColumnTooltip = React.createClass({
+  propTypes: {
+    attr: React.PropTypes.string.isRequired,
+    info: React.PropTypes.object.isRequired
+  },
   render: function() {
     var infoText = this.props.info['Description'],
         infoType = this.props.info['Type'];
     return (
-      <div className="tooltip" data-attribute={this.props.attr}>
+      <div className="tooltip">
         <p className="description">{infoText}</p>
         <p className="type">Type: <strong>{infoType}</strong></p>
       </div>

--- a/cycledash/static/js/examine/VCFTable.js
+++ b/cycledash/static/js/examine/VCFTable.js
@@ -65,7 +65,7 @@ var VCFTableHeader = React.createClass({
     attrs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired
   },
   handleChartToggle: function(e) {
-    var attribute = e.target.attributes.getNamedItem('data-attribute').value;
+    var attribute = e.currentTarget.attributes.getNamedItem('data-attribute').value;
     this.props.handleChartChange(attribute);
   },
   render: function() {
@@ -91,7 +91,7 @@ var InfoColumnTh = React.createClass({
   render: function() {
     return (
       <th className="attr" onClick={this.props.handleChartToggle} data-attribute={this.props.attr}>
-        {this.props.attr}
+        <span>{this.props.attr}</span>
         <InfoColumnTooltip info={this.props.info} attr={this.props.attr} />
       </th>
     );

--- a/cycledash/static/js/examine/examine.js
+++ b/cycledash/static/js/examine/examine.js
@@ -26,6 +26,7 @@ var ExaminePage = React.createClass({
    },
    getDefaultProps: function() {
      return {records: [],
+             header: {},
              truthRecords: [],
              karyogram: initializeKaryogram(),
              chromosomes: [],
@@ -33,10 +34,11 @@ var ExaminePage = React.createClass({
    },
    componentDidMount: function() {
      d3.xhr('/vcf' + this.props.vcfPath, function(err, response) {
-       var records = vcf()
+       var parsedVcf  = vcf()
                         .parseChrom(function(chr){ return 'chr' + chr; })
-                        .data(response.responseText)
-                        .data(),
+                        .data(response.responseText),
+           records = parsedVcf.data(),
+           header = parsedVcf.header(),
            attrs = _.keys(records[0].INFO),
            chromosomes = chromosomesFrom(records);
 
@@ -46,7 +48,7 @@ var ExaminePage = React.createClass({
                               .data(response.responseText)
                               .data();
 
-         this.setProps({records: records, chromosomes: chromosomes,
+         this.setProps({records: records, header: header, chromosomes: chromosomes,
                         attrs: attrs, truthRecords: truthRecords});
        }.bind(this))
      }.bind(this));
@@ -138,7 +140,7 @@ var ExaminePage = React.createClass({
                     karyogram={this.props.karyogram}
                     handleRangeChange={this.handleRangeChange} />
          <VCFTable records={filteredRecords} position={this.state.position}
-                   attrs={this.props.attrs}
+                   header={this.props.header} attrs={this.props.attrs}
                    handleChartChange={this.handleChartChange}
                    handleFilterUpdate={this.handleFilterUpdate}
                    handleChromosomeChange={this.handleChromosomeChange}


### PR DESCRIPTION
Adds CSS tooltips to display the INFO attribute description and type from the VCF, as well as a slight underline as an unobtrusive affordance for the user.

![](http://cl.ly/image/2J3z0x3S3u1r/Screen%20Shot%202014-09-17%20at%207.04.12%20PM.png)

fixes #35

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/43)

<!-- Reviewable:end -->
