### PR TITLE
Use text-shadow rather than bolding on navigation.

### DIFF
--- a/cycledash/static/css/header.css
+++ b/cycledash/static/css/header.css
@@ -13,17 +13,16 @@ nav.navigation ul {
 nav.navigation li {
     display: inline-block;
     padding: 2px 11px;
-    min-width: 60px;
 }
 nav.navigation a {
     color: black;
     text-decoration: none;
 }
 nav.navigation a:hover {
-    text-shadow:0px 0px 1px black;
+    text-decoration: underline;
 }
 nav.navigation .active a:hover {
-    text-shadow: none;
+    text-decoration: none;
 }
 nav.navigation .active {
     font-weight: bold;


### PR DESCRIPTION
This prevents the nav bar from shifting on hover.

Demo: http://dans-macbook-pro.local:5000/runs/1/examine
