### PR TITLE
Examine Page: Sort records by chromosome & postion

### DIFF
--- a/cycledash/static/js/examine/ExaminePage.js
+++ b/cycledash/static/js/examine/ExaminePage.js
@@ -60,12 +60,14 @@ var ExaminePage = React.createClass({
 
     $.when(deferredVcf(this.props.vcfPath), deferredVcf(this.props.truthVcfPath))
       .done((vcfData, truthVcfData) => {
-        var records = vcfData.records;
+        var records = vcfData.records,
+            chromosomes = _.uniq(records.map((r) => r.CHROM));
+        chromosomes.sort(vcfTools.chromosomeComparator);
         this.setProps({
           hasLoaded: true,
           records: records,
           truthRecords: truthVcfData.records,
-          chromosomes: chromosomesFrom(records),
+          chromosomes: chromosomes,
           attrs: _.keys(records[0].INFO),
           header: vcfData.header
         });
@@ -166,6 +168,9 @@ var ExaminePage = React.createClass({
                                                   this.isRecordWithinRange,
                                                   this.isRecordCorrectVariantType);
 
+    filteredRecords.sort(vcfTools.recordComparator);
+    filteredTruthRecords.sort(vcfTools.recordComparator);
+
     return (
         <div className="examine-page">
           <h1>Examining: <small>{this.props.vcfPath}</small></h1>
@@ -199,17 +204,6 @@ var ExaminePage = React.createClass({
      );
    }
 });
-
-function chromosomesFrom(records) {
-  return _.reduce(records, function(acc, val, key) {
-     var chromosome = val.CHROM;
-     if (acc.mem[chromosome] === undefined) {
-       acc.mem[chromosome] = true;
-       acc.chromosomes.push(chromosome);
-     }
-     return acc;
-   }, {chromosomes: [], mem: {}}).chromosomes;
-}
 
 function initializeKaryogram() {
   return idiogrammatik()

--- a/cycledash/static/js/examine/vcf.tools.js
+++ b/cycledash/static/js/examine/vcf.tools.js
@@ -30,16 +30,7 @@ function chromosomeComparator(a, b) {
 }
 
 function recordComparator(a, b) {
-  if (a.CHROM != b.CHROM) {
-    return chromosomeComparator(a.CHROM, b.CHROM);
-  } else {
-    if (a.POS > b.POS)
-      return 1;
-    else if (a.POS < b.POS)
-      return -1;
-    else
-      return 0;
-  }
+  return chromosomeComparator(a.CHROM, b.CHROM) || (a.POS - b.POS);
 }
 
 /**

--- a/cycledash/static/js/examine/vcf.tools.js
+++ b/cycledash/static/js/examine/vcf.tools.js
@@ -14,6 +14,34 @@ function recordKey(record) {
   return record.__KEY__;
 }
 
+function chromosomeComparator(a, b) {
+  var aChr = Number(a) || a,
+      bChr = Number(b) || b;
+  if (aChr == bChr)
+    return 0;
+  else if (_.isString(aChr) && _.isString(bChr))
+    return aChr < bChr ? -1 : 1; // we want alphabetical ordering
+  else if (_.isNumber(aChr) && _.isNumber(bChr))
+    return aChr > bChr ? 1 : -1;
+  else if (_.isString(aChr))
+    return 1
+  else
+    return -1;
+}
+
+function recordComparator(a, b) {
+  if (a.CHROM != b.CHROM) {
+    return chromosomeComparator(a.CHROM, b.CHROM);
+  } else {
+    if (a.POS > b.POS)
+      return 1;
+    else if (a.POS < b.POS)
+      return -1;
+    else
+      return 0;
+  }
+}
+
 /**
  * Returns {truePositives, falsePositives, falseNegatives} for the given records
  * and truthRecords.
@@ -154,5 +182,7 @@ function doRecordsOverlap(aRecord, bRecord) {
 module.exports = {
   trueFalsePositiveNegative: trueFalsePositiveNegative,
   trueFalsePositiveNegativeForSvs: trueFalsePositiveNegativeForSvs,
-  trueFalsePositiveNegativeForSnvAndIndels: trueFalsePositiveNegativeForSnvAndIndels
+  trueFalsePositiveNegativeForSnvAndIndels: trueFalsePositiveNegativeForSnvAndIndels,
+  chromosomeComparator: chromosomeComparator,
+  recordComparator: recordComparator
 };


### PR DESCRIPTION
This change also sorts chromosomes in the dropdown chromosome select
box.

Filtered records are sorted on every ExaminePage render.

This change results in a performance hit on every re-render. This is
only noticable when sorting more than >20k or so records. With 40k
records, the penalty is about 700ms if sorting all 40k of them (an
uncommon case). Fixing this is probably worth doing, but doing it right
will have far-reaching consequences better relegated to a different
branch.

fixes #61
fixes #62

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/79)

<!-- Reviewable:end -->
