### PR TITLE
Enable sorting of numerical columns

### DIFF
--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -31,10 +31,12 @@ input {
 th#position input {
     width: 100px;
 }
-th.attr {
+th {
+    font-size: 19px;
     position: relative;
 }
-th.attr > span {
+th.attr > span.chartable {
+    cursor: pointer;
     border-bottom: 1px dashed #333;
 }
 th.attr.selected > span {
@@ -104,9 +106,17 @@ table {
 tr:nth-child(odd) {
     background: rgba(248, 249, 250, 0.5);
 }
-th.attr {
-    font-size: 21px;
+th .sort {
     cursor: pointer;
+}
+th .sort:before {
+    content: ' ↕';
+}
+th .sorting-by.asc:before {
+    content: ' ↑';
+}
+th .sorting-by.desc:before {
+    content: ' ↓';
 }
 th.attr:hover {
     font-weight: bold;

--- a/cycledash/static/js/examine/ExaminePage.js
+++ b/cycledash/static/js/examine/ExaminePage.js
@@ -44,7 +44,6 @@ var ExaminePage = React.createClass({
   },
   getInitialState: function() {
     return {chartAttributes: [],
-            records: [],
             sortBy: [null, 'desc'], // null sorts by default = CHR/POS
             variantType: 'All',
             filters: {},
@@ -55,6 +54,7 @@ var ExaminePage = React.createClass({
   },
   getDefaultProps: function() {
     return {header: {},
+            records: [],
             truthRecords: [],
             karyogram: initializeKaryogram(),
             chromosomes: [],

--- a/cycledash/static/js/examine/ExaminePage.js
+++ b/cycledash/static/js/examine/ExaminePage.js
@@ -38,6 +38,7 @@ var ExaminePage = React.createClass({
     tumorBamPath:  React.PropTypes.string,
     chromosomes: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
     attrs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
+    records: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
     truthRecords: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
     igvHttpfsUrl: React.PropTypes.string.isRequired
   },
@@ -73,9 +74,9 @@ var ExaminePage = React.createClass({
         var records = vcfData.records,
             chromosomes = _.uniq(records.map((r) => r.CHROM));
         chromosomes.sort(vcfTools.chromosomeComparator);
-        this.setState({records: records});
         this.setProps({
           hasLoaded: true,
+          records: records,
           truthRecords: truthVcfData.records,
           chromosomes: chromosomes,
           attrs: _.keys(records[0].INFO),
@@ -193,7 +194,7 @@ var ExaminePage = React.createClass({
     });
   },
   getFilteredSortedRecords: function() {
-    var filteredRecords = this.filterRecords(this.state.records,
+    var filteredRecords = this.filterRecords(this.props.records,
                                              this.isRecordWithinRange,
                                              this.doesRecordPassFilters,
                                              this.isRecordCorrectVariantType);
@@ -202,10 +203,11 @@ var ExaminePage = React.createClass({
       filteredRecords.sort(vcfTools.recordComparator(direction));
     } else {
       filteredRecords.sort((a, b) => {
-        if (direction === 'desc')
+        if (direction === 'desc') {
           return a.INFO[sortByAttr] - b.INFO[sortByAttr];
-        else
+        } else {
           return b.INFO[sortByAttr] - a.INFO[sortByAttr];
+        }
       });
     }
     return filteredRecords;
@@ -225,7 +227,7 @@ var ExaminePage = React.createClass({
                         variantType={this.state.variantType}
                         handleVariantTypeChange={this.handleVariantTypeChange}
                         records={filteredRecords}
-                        unfilteredRecords={this.state.records}
+                        unfilteredRecords={this.props.records}
                         truthRecords={filteredTruthRecords} />
           <AttributeCharts records={filteredRecords}
                            chartAttributes={this.state.chartAttributes} />

--- a/cycledash/static/js/examine/VCFTable.js
+++ b/cycledash/static/js/examine/VCFTable.js
@@ -27,7 +27,7 @@ var VCFTable = React.createClass({
     records: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
     // The VCF header, used to get information about the INFO fields
     header: React.PropTypes.object.isRequired,
-    // Attribute being sorted by
+    // Attribute by which we are sorting
     sortBy: React.PropTypes.array,
     handleSortByChange: React.PropTypes.func.isRequired,
     handleChromosomeChange: React.PropTypes.func.isRequired,
@@ -78,17 +78,17 @@ var VCFTableHeader = React.createClass({
     attrs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
     // Subset of attrs which are currently selected.
     selectedAttrs: React.PropTypes.arrayOf(React.PropTypes.string).isRequired,
-    // Attribute being sorted by
+    // Attribute by which we are sorting
     sortBy: React.PropTypes.array
   },
   handleChartToggle: function(e) {
     var attribute = e.currentTarget.parentElement
-      .attributes.getNamedItem('data-attribute').value;
+        .attributes.getNamedItem('data-attribute').value;
     this.props.handleChartChange(attribute);
   },
   handleSortByChange: function(e) {
     var attribute = e.currentTarget.parentElement
-      .attributes.getNamedItem('data-attribute').value;
+        .attributes.getNamedItem('data-attribute').value;
     if (attribute === 'position')
       attribute = null;
     var [sortAttr, direction] = this.props.sortBy;
@@ -111,7 +111,7 @@ var VCFTableHeader = React.createClass({
                            handleChartToggle={this.handleChartToggle} />;
     }.bind(this));
 
-    var propClasses = React.addons.classSet({
+    var sorterClasses = React.addons.classSet({
       'sort': true,
       'desc': this.props.sortBy[1] === 'desc',
       'asc': this.props.sortBy[1] === 'asc',
@@ -124,7 +124,7 @@ var VCFTableHeader = React.createClass({
           <th>Chromosome</th>
           <th data-attribute="position">
             Position
-            <a className={propClasses} onClick={this.handleSortByChange}></a>
+            <a className={sorterClasses} onClick={this.handleSortByChange}></a>
           </th>
           <th>REF / ALT</th>
           {attrs}

--- a/cycledash/static/js/examine/vcf.tools.js
+++ b/cycledash/static/js/examine/vcf.tools.js
@@ -29,8 +29,14 @@ function chromosomeComparator(a, b) {
     return -1;
 }
 
-function recordComparator(a, b) {
-  return chromosomeComparator(a.CHROM, b.CHROM) || (a.POS - b.POS);
+function recordComparator(direction) {
+  return function(a, b) {
+    if (direction === 'desc' || !direction) {
+      return chromosomeComparator(a.CHROM, b.CHROM) || (a.POS - b.POS);
+    } else if (direction === 'asc') {
+      return chromosomeComparator(b.CHROM, a.CHROM) || (b.POS - a.POS);
+    }
+  }
 }
 
 /**


### PR DESCRIPTION
Columns (float or integer type) may be sorted in ascending or descending
order, by clicking arrows next to the header titles.

Additionally, CSS rules were changed and event listeners removed for
columns which cannot reasonable be charted (i.e. you can only chart
columns with a number type: gone are the days of weird histograms of
booleans or strings).

This involves moving records from props to state.

![](http://cl.ly/image/1n013m3J1r1S/Screen%20Shot%202014-09-26%20at%201.15.47%20PM.png)

fixes #71

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/85)

<!-- Reviewable:end -->
