### PR TITLE
Make BioDalliance less giant on short screens

### DIFF
--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -257,3 +257,13 @@ text {
   max-height: 300px;
   min-height: 300px;
 }
+
+@media(max-height:1000px) {
+  .variant-inspector {
+    height: 550px;
+  }
+  .dalliance .tier.pileup {
+    max-height: 200px;
+    min-height: 200px;
+  }
+}


### PR DESCRIPTION
Fixes #117.

Before: 
![short-screen-before](https://cloud.githubusercontent.com/assets/98301/4621666/00f54408-532f-11e4-8d3e-b50b3498e76a.png)

After:
![short-screen-after](https://cloud.githubusercontent.com/assets/98301/4621670/02b9464a-532f-11e4-9f6a-0f7ad363604e.png)
