### PR TITLE
Compress text/javascript files, too

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,7 +17,7 @@ TYPEKIT_URL = os.environ.get('TYPEKIT_URL', None)
 
 # These are the same as Compress's defaults, but with 'text/plain' added.
 # This is important to us because VCF file are transmitted as 'text/plain'.
-COMPRESS_DEBUG=True
+COMPRESS_DEBUG=True  # use gzip, even in DEBUG mode.
 COMPRESS_MIMETYPES=['text/html', 'text/plain', 'text/css', 'text/xml',
                     'text/javascript',
                     'application/json', 'application/javascript']


### PR DESCRIPTION
This was preventing large files like `bundled.js` from being compressed over the wire. They were being sent with `Content-type: text/javascript` instead of `Content-type: application/javascript`.

As for what they _should_ be sent with, it seems [murky](http://stackoverflow.com/a/4101763/388951).

The `COMPRESS_DEBUG` param enables gzip for the local Flask dev server. Seems very 12 factory.
