### PR TITLE
Fixing tooltip word wrap

### DIFF
--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -90,6 +90,7 @@ th.uber-column:last-child {
 .vcf-table .tooltip {
     display: none;
     word-wrap: break-word;
+    white-space: normal;
     border-radius: 3px;
     position: absolute;
     top: 110%;


### PR DESCRIPTION
Let me know if you think it's too hacky to leave the th { white-space: nowrap } and simply override it for the tooltip. The way things are laid out, that seemed the easiest approach.

I'll update the difftest image when my difftest tooltip change is merged into master.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/198)

<!-- Reviewable:end -->
