### PR TITLE
Use tmpfile config for psql copy

### DIFF
--- a/ENVTEMPLATE.sh
+++ b/ENVTEMPLATE.sh
@@ -5,8 +5,16 @@ export CELERY_BROKER='amqp://localhost'
 export WEBHDFS_USER=username
 export WEBHDFS_URL=http://example.com:5000
 export IGV_HTTPFS_URL=http://example.com:9876
-export USE_RELOADER=False  # True for automatic reloading & debugging JS
-                           # insertion.
 
-#  Optional:
+# True for automatic reloading & debugging JS insertion.
+export USE_RELOADER=False
+
+
+###  Optional:
+## This is one way to get fancy fonts working in CycleDash.
 # export TYPEKIT_URL="//use.typekit.net/SOMETHING.js"
+
+## Useful to specify where CSV files will be written to when importing data into
+## Postgres via CSV, which is how workers/genotype_extractor.py works.
+## Default = '/tmp'
+# export TEMPORARY_DIR='/users/donjoe/tmp'

--- a/cycledash/views.py
+++ b/cycledash/views.py
@@ -64,7 +64,6 @@ def runs():
             response = jsonify({'error': 'Run validation', 'message': str(e)})
             response.status_code = 400
             return response
-        print data
         start_workers_for_run(data)
         return redirect(url_for('runs'))
     elif request.method == 'GET':

--- a/schema.sql
+++ b/schema.sql
@@ -20,27 +20,25 @@ CREATE TABLE vcf_annotations (
        vcf_id BIGINT REFERENCES vcfs NOT NULL,
        annotation TEXT NOT NULL,
        type TEXT NOT NULL,
-       "contig:start" TEXT,
-       "contig:end" TEXT,
-       "position:start" TEXT,
-       "position:end" TEXT
+       "contig" TEXT,
+       "position:start" INTEGER,
+       "position:end" INTEGER
 );
 
 CREATE TABLE data_annotations (
        dataset_name TEXT, -- The denormalized foreign key of a dataset, stored in the vcfs table.
        annotation TEXT NOT NULL,
        type TEXT NOT NULL,
-       "contig:start" TEXT,
-       "contig:end" TEXT,
-       "position:start" TEXT,
-       "position:end" TEXT
+       "contig" TEXT,
+       "position:start" INTEGER,
+       "position:end" INTEGER
 );
 
 CREATE TABLE genotypes (
        vcf_id BIGINT REFERENCES vcfs NOT NULL,
        sample_name TEXT,
        contig TEXT,
-       position TEXT,
+       position INTEGER,
        id TEXT,
        reference TEXT,
        alternates TEXT,

--- a/workers/genotype_extractor.py
+++ b/workers/genotype_extractor.py
@@ -9,7 +9,8 @@ actually contain values, and stores a list of them in the vcf table.
 import json
 from sqlalchemy import create_engine, MetaData
 
-from workers.shared import load_vcf_from_hdfs, worker, DATABASE_URI
+from workers.shared import (load_vcf_from_hdfs, worker,
+                            DATABASE_URI, TEMPORARY_DIR)
 from workers.relational_vcfs import insert_vcf_with_copy
 
 
@@ -29,7 +30,8 @@ def extractor(run):
     insert_vcf_metadata(metadata, run, header)
     vcf_id = get_vcf_id(connection, run)
     insert_vcf_with_copy(reader, 'genotypes', engine,
-                         default_values={'vcf_id': vcf_id})
+                         default_values={'vcf_id': vcf_id},
+                         temporary_dir=TEMPORARY_DIR)
 
     # Now we determine which columns actually exist in this VCF, and cache them
     # (as this is a time-consuming operation) in the vcfs table for later use.

--- a/workers/shared.py
+++ b/workers/shared.py
@@ -21,6 +21,8 @@ CONCORDANCE_URL = 'http://localhost:{}/runs/{}/concordance'
 
 DATABASE_URI = os.environ['DATABASE_URI']
 
+TEMPORARY_DIR = os.environ.get('TEMPORARY_DIR', None)
+
 worker = celery.Celery(broker=CELERY_BROKER, backend=CELERY_BACKEND)
 
 


### PR DESCRIPTION
This is useful because the Postgres process in our deployment can't
access the e.g. /tmp dir Python writes tempfiles to by default. Now we
can specify where our intermediate CSV files are written to so that
postgres can read them.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/242)

<!-- Reviewable:end -->
