### PR TITLE
Derive Truth VCF for stats calculation

### DIFF
--- a/cycledash/genotypes.py
+++ b/cycledash/genotypes.py
@@ -14,7 +14,8 @@ WHERE id = %(vcf_id)s
 TRUTH_BY_DATASET_QUERY = """SELECT *
 FROM vcfs
 WHERE dataset_name = %(dataset_name)s
-  AND validation_vcf = true"""
+  AND validation_vcf = true
+"""
 
   ##############################################################################
  ##### The below functions are exposed via the controllers in views.py. #######

--- a/cycledash/genotypes.py
+++ b/cycledash/genotypes.py
@@ -6,6 +6,16 @@ import vcf
 from cycledash import db
 
 
+VCF_BY_ID_QUERY = """SELECT *
+FROM vcfs
+WHERE id = %(vcf_id)s
+"""
+
+TRUTH_BY_DATASET_QUERY = """SELECT *
+FROM vcfs
+WHERE dataset_name = %(dataset_name)s
+  AND validation_vcf = true"""
+
   ##############################################################################
  ##### The below functions are exposed via the controllers in views.py. #######
 ##############################################################################
@@ -70,8 +80,10 @@ def get(vcf_id, query):
                                                    vcf_id, fns)
         genotypes = connection.execute(combined_sql, parameters)
         genotypes = [dict(gt) for gt in genotypes.fetchall()]
-    # TODO: derive truth_vcf, replace None with it
-    stats = calculate_stats(vcf_id, None, query)
+    # TODO(ihodes): We try to guess it later; should give users a chance to
+    #               specify it (or multiple validations) in UI.
+    truth_vcf_id = None
+    stats = calculate_stats(vcf_id, truth_vcf_id, query)
     return {'records': genotypes, 'stats': stats}
 
 
@@ -80,7 +92,6 @@ def calculate_stats(vcf_id, truth_vcf_id, query):
     to query.
     """
     with db.engine.connect() as connection:
-        # TODO(ihodes): Try to guess truth_vcf_id if it's None.
         parameters = {'vcf_id': vcf_id}
         count_query = "SELECT count(*) FROM genotypes WHERE vcf_id = %(vcf_id)s"
         record_query = count_query
@@ -90,6 +101,15 @@ def calculate_stats(vcf_id, truth_vcf_id, query):
             record_query += '\n' + sql
         count = connection.execute(record_query, parameters).fetchall()[0][0]
         total_count = connection.execute(count_query, parameters).fetchall()[0][0]
+
+        # Try to guess truth_vcf_id if it's None.
+        if truth_vcf_id is None:
+            vcf = connection.execute(VCF_BY_ID_QUERY, vcf_id=vcf_id).first()
+            truth_rel = connection.execute(TRUTH_BY_DATASET_QUERY,
+                                           dataset_name=vcf['dataset_name']).first()
+            if truth_rel:
+                truth_vcf_id = truth_rel.id
+
         stats = genotype_statistics(connection, query, vcf_id, truth_vcf_id,
                                     count, total_count)
     return stats

--- a/cycledash/templates/runs.html
+++ b/cycledash/templates/runs.html
@@ -43,7 +43,6 @@ input.selector {
 {% block body %}
 {{ nav("runs") }}
 <br/>
-<button id="concordance" class="btn btn-info">Concordance on Selected</button>
 <button id="show-submit" class="btn btn-default">Submit New Run</button>
 <form method="POST" action="/runs" role="form" id="submit">
   <h2>Add a new run:<button type="button" class="close" aria-hidden="true">&times;</button></h3>
@@ -93,40 +92,31 @@ input.selector {
   <button type="submit" class="btn btn-success">Submit</button>
 </form>
 
-<script>
-  d3.select("#concordance")
-    .on("click", function() {
-      var runs = document.querySelectorAll("input[type=checkbox]:checked");
-      runs = Array.prototype.slice.call(runs).map(function(v) { return v.value; });
-      if (runs.length != 0) {
-        var run_ids_key = runs.join(",");
-        window.location.href = "/runs/" + run_ids_key + "/concordance";
-      }
-    });
-</script>
-
 <table class="runs table">
   <thead>
     <tr>
       <th></th>
       <th>Caller Name</th>
-      <th>Submitted On</th>
       <th>Dataset</th>
+      <th>Submitted On</th>
+      <th></th>
     </tr>
   </thead>
   <tbody>
 {%- for run in runs %}
     <tr class="run" data-runId="{{ run['id'] }}">
       <td>
-        <input type="checkbox" value="{{ run['id'] }}" class="selector">
         <a class="btn btn-default btn-xs" href="/runs/{{ run['id'] }}/examine">Examine</a>
       </td>
       <td>{{ run['caller_name'] }}</td>
-      <td>{{ run['created_at'] }}</td>
       <td>{{ run['dataset_name'] }}</td>
+      <td>{{ run['created_at'] }}</td>
+      <td>
+        {%- if run['validation_vcf'] %}<span class="label label-info">validation</span>{% endif -%}
+      </td>
     </tr>
     <tr class="run-info" data-runId="{{ run['id'] }}">
-      <td colspan=4>
+      <td colspan=5>
         <ul>
           {% for name, key in run_kvs.iteritems() %}
           {%- if run.get(key) %}

--- a/cycledash/validations.py
+++ b/cycledash/validations.py
@@ -26,6 +26,7 @@ def Castable(t):
 CreateRunSchema = Schema({
     Required('variant_caller_name'): unicode,
     Required('vcf_path'): PathString,
+    'truth_vcf_path': PathString,
     'normal_path': PathString,
     'tumor_path': PathString,
     'is_validation': bool,

--- a/cycledash/views.py
+++ b/cycledash/views.py
@@ -25,7 +25,7 @@ WEBHDFS_OPEN_OP = '?user.name={}&op=OPEN'.format(app.config['WEBHDFS_USER'])
 
 RUN_ADDL_KVS = {'Tumor BAM': 'tumor_bam_uri',
                 'Normal BAM': 'normal_bam_uri',
-                'VCF': 'uri',
+                'VCF URI': 'uri',
                 'Notes': 'notes'}
 
 

--- a/workers/relational_vcfs.py
+++ b/workers/relational_vcfs.py
@@ -140,12 +140,11 @@ def insert_csv(filename, tablename, engine):
     return cur
 
 
-def insert_vcf_with_copy(vcfreader, tablename, engine, **kwargs):
+def insert_genotypes_with_copy(vcfreader, engine, **kwargs):
     """Inserts the calls from the VCF into the given table in engine
 
     Args:
         vcfreader: A PyVCF Reader object on the VCF being inserted.
-        tablename: The string name of the table being inserted into.
         engine: A SQLAlchemy engine object to the database.
 
     Optional Args:
@@ -164,8 +163,8 @@ def insert_vcf_with_copy(vcfreader, tablename, engine, **kwargs):
     con = engine.connect()
     meta = sqlalchemy.MetaData(bind=con)
     meta.reflect()
-    table = meta.tables.get(tablename)
+    table = meta.tables.get('genotypes')
     table_cols = columns(table)
     filename = vcf_to_csv(vcfreader, table_cols, None, **kwargs)
-    insert_csv(filename, tablename, engine)
+    insert_csv(filename, 'genotypes', engine)
     con.close()


### PR DESCRIPTION
This fixes #251, deriving truth VCFs for calculation of TFPN stats on
the Examine page. If a validation VCF exists for a given dataset, the
first one returned by a query for such a VCF is inferred and used.

This fixes #267, so truth VCFs can be submitted.

This adds a badge to the runs table on truth VCFs, indicating to the
user that the VCF displayed there is a validation VCF.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/269)

<!-- Reviewable:end -->
