### PR TITLE
Match CQL Box with rest of Examine CSS

### DIFF
--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -324,10 +324,10 @@ text {
     width: 18px;
     height: 18px;
     z-index: 1;
-    border-radius: 20px;
 }
 .query-status.good {
     background: rgb(125, 236, 182);
+    border-radius: 20px;
 }
 .query-status.good:before {
     content: "✓";
@@ -338,6 +338,7 @@ text {
 }
 .query-status.bad {
     background: rgb(243, 45, 45);
+    border-radius: 1px;
 }
 .query-status.bad:before {
     content: "×";

--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -321,22 +321,37 @@ text {
     left: 10px;
     top: 50%;
     margin-top: -8px;
-    width: 16px;
-    height: 16px;
+    width: 18px;
+    height: 18px;
     z-index: 1;
     border-radius: 20px;
 }
 .query-status.good {
     background: rgb(125, 236, 182);
 }
+.query-status.good:before {
+    content: "✓";
+    position: relative;
+    left: 3px;
+    bottom: 2px;
+    color: white;
+}
 .query-status.bad {
     background: rgb(243, 45, 45);
+}
+.query-status.bad:before {
+    content: "×";
+    position: relative;
+    left: 3px;
+    bottom: 8px;
+    font-size: 1.5em;
+    color: white;
 }
 .tt-hint {
     color: gray;
 }
 .error-message {
-    min-height: 20px;
+    display: none;
 }
 
 /* Styles from http://stackoverflow.com/a/20205623/388951 */

--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -93,7 +93,7 @@ th.uber-column {
     top: 110%;
     right: -72px;
     background: white;
-    border: 1px solid #343434;
+    border: 1px solid #B6B6B7;
     width: 250px;
     font-size: 12px;
     font-color: #3d3d3d;
@@ -128,7 +128,7 @@ th.uber-column {
 }
 .vcf-table .tooltip:before {
     border-color: rgba(52, 52, 52, 0);
-    border-bottom-color: #343434;
+    border-bottom-color: #B6B6B7;
     border-width: 11px;
     margin-left: -11px;
 }
@@ -215,7 +215,7 @@ text {
 }
 #stats-container .precision-recall {
     border-radius: 3px 3px 0 0;
-    border: 1px solid black;
+    border: 1px solid #B6B6B7;
     margin-top: -17px;
     padding: 13px 0px;
 }
@@ -225,7 +225,7 @@ text {
 }
 #stats-container .total-records {
     text-align: center;
-    border: 1px solid black;
+    border: 1px solid #B6B6B7;
     border-top: none;
     padding: 3px 0;
     border-radius: 0 0 3px 3px;
@@ -254,7 +254,7 @@ text {
 #svgHolder {
     position: relative;
     bottom: 0;
-    border: 1px solid #ccc;
+    border: 1px solid #B6B6B7;
     overflow-y: auto;
     margin: 0 5%;
     padding: 10px;
@@ -292,50 +292,51 @@ text {
 /* CQL Typeahead */
 .query-container * { box-sizing: border-box; }
 .typeahead-input {
-  position: relative;
-  padding-right: 350px;  /* matches width of Stats Table */
-  margin-bottom: 20px;
-  /* reference, alternates */
+    position: relative;
+    padding-right: 350px;  /* matches width of Stats Table */
+    margin-bottom: 20px;
+    /* reference, alternates */
 }
 .twitter-typeahead {
-  width: 100%;
-  padding-right: 20px;
+    width: 100%;
+    padding-right: 20px;
 }
 .query-input, .twitter-typeahead .tt-query, .twitter-typeahead .tt-hint {
-  width: 100%;
-  height: 40px;
-  padding: 8px 12px;
-  font-size: 24px;
-  line-height: 30px;
-  border: 2px solid #ccc;
-  -webkit-border-radius: 8px;
-     -moz-border-radius: 8px;
-          border-radius: 8px;
-  outline: none;
-  padding-left: 30px;
+    width: 100%;
+    height: 40px;
+    padding: 8px 12px;
+    font-size: 22px;
+    line-height: 30px;
+    border: 1px solid #B6B6B7;
+    border-radius: 5px;
+    outline: none;
+    padding-left: 37px;
+}
+.query-container input {
+    font-family: "inconsolatas", monospace !important;
+    font-weight: 200;
 }
 .query-status {
-  position: absolute;
-  left: 10px;
-  top: 50%;
-  margin-top: -8px;
-  width: 16px;
-  height: 16px;
-  z-index: 1;
+    position: absolute;
+    left: 10px;
+    top: 50%;
+    margin-top: -8px;
+    width: 16px;
+    height: 16px;
+    z-index: 1;
+    border-radius: 20px;
 }
 .query-status.good {
-  background: green;
+    background: rgb(125, 236, 182);
 }
 .query-status.bad {
-  background: red;
+    background: rgb(243, 45, 45);
 }
-
 .tt-hint {
-  color: gray;
+    color: gray;
 }
-
 .error-message {
-  min-height: 20px;
+    min-height: 20px;
 }
 
 /* Styles from http://stackoverflow.com/a/20205623/388951 */


### PR DESCRIPTION
Changed the font to match our monospace font, made the squares circles, borders match borders of other items on page, colors are more muted like other colors on page. Obviously this is pretty subjective, so feel free to hate it & we can change it to make everyone happy. I think the page in general needs a little love, but figured this might be a small improvement to bring the querybox more in line with the rest of the page.

![](http://cl.ly/image/2c143x3s2J37/Screen%20Shot%202014-11-22%20at%201.57.23%20PM.png)
![](http://cl.ly/image/2d27200q0Z2B/Screen%20Shot%202014-11-22%20at%201.57.18%20PM.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/272)

<!-- Reviewable:end -->
