### PR TITLE
Run pylint on Travis

### DIFF
--- a/cycledash/__init__.py
+++ b/cycledash/__init__.py
@@ -1,5 +1,5 @@
 from flask import Flask
-from flask.ext.sqlalchemy import SQLAlchemy
+from flask_sqlalchemy import SQLAlchemy
 
 
 def initialize_application():

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ voluptuous==0.8.5
 wsgiref==0.1.2
 dpxdt==0.1.5
 psycopg2==2.5.4
-
+pylint==1.4.0

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -5,4 +5,10 @@ find cycledash/static/js -name '*.js' \
   | grep -v /dist/ | grep -v 'bundled' \
   | xargs ./node_modules/.bin/jsxhint
 
-echo 'Passes jsxhint lint check'
+find . -name '*.py' \
+  | xargs pylint \
+  --errors-only \
+  --disable=print-statement \
+  --ignored-classes=SQLAlchemy,Run,Concordance,scoped_session,pysam
+
+echo 'Passes jsxhint and pylint check'


### PR DESCRIPTION
Python modules with magical loaders don't play well with pylint.

I disabled checks on those classes—this should at least get us linting on our own code!
