### PR TITLE
Upgrade React and related packages to 0.12.1

### DIFF
--- a/cycledash/static/js/CompletionUtils.js
+++ b/cycledash/static/js/CompletionUtils.js
@@ -2,7 +2,6 @@
  * Utility functions to help with query completion.
  *
  * These are exported from a separate module to facilitate testing.
- *
  */
 'use strict';
 

--- a/cycledash/static/js/CompletionUtils.js
+++ b/cycledash/static/js/CompletionUtils.js
@@ -3,7 +3,6 @@
  *
  * These are exported from a separate module to facilitate testing.
  *
- * @jsx React.DOM
  */
 'use strict';
 

--- a/cycledash/static/js/QueryCompletion.js
+++ b/cycledash/static/js/QueryCompletion.js
@@ -11,7 +11,6 @@
  * to build a set of possible completions. It then culls this set down to those
  * which parse correctly and are extensions of what the user has typed.
  *
- * @jsx React.DOM
  */
 'use strict';
 

--- a/cycledash/static/js/QueryCompletion.js
+++ b/cycledash/static/js/QueryCompletion.js
@@ -10,7 +10,6 @@
  * This completion engine fills in all possible values of each expression type
  * to build a set of possible completions. It then culls this set down to those
  * which parse correctly and are extensions of what the user has typed.
- *
  */
 'use strict';
 

--- a/cycledash/static/js/QueryLanguage.js
+++ b/cycledash/static/js/QueryLanguage.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 'use strict';
 
 var parser = require('../lib/querylanguage.js'),

--- a/cycledash/static/js/examine/RecordActions.js
+++ b/cycledash/static/js/examine/RecordActions.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 

--- a/cycledash/static/js/examine/RecordStore.js
+++ b/cycledash/static/js/examine/RecordStore.js
@@ -7,8 +7,7 @@
  *
  * Beware the mutable function-local state defined at the beginning of
  * RecordStore. This is what we want to hide from the outside world
- *
- * @jsx React.DOM */
+ */
 "use strict";
 
 var _ = require('underscore'),

--- a/cycledash/static/js/examine/components/AttributeCharts.js
+++ b/cycledash/static/js/examine/components/AttributeCharts.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var _ = require('underscore'),

--- a/cycledash/static/js/examine/components/BioDalliance.js
+++ b/cycledash/static/js/examine/components/BioDalliance.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var React = require('react'),

--- a/cycledash/static/js/examine/components/ExamineInformation.js
+++ b/cycledash/static/js/examine/components/ExamineInformation.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var _ = require('underscore'),

--- a/cycledash/static/js/examine/components/ExaminePage.js
+++ b/cycledash/static/js/examine/components/ExaminePage.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var _ = require('underscore'),

--- a/cycledash/static/js/examine/components/Karyogram.js
+++ b/cycledash/static/js/examine/components/Karyogram.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 'use strict';
 
 var _ = require('underscore'),

--- a/cycledash/static/js/examine/components/QueryBox.js
+++ b/cycledash/static/js/examine/components/QueryBox.js
@@ -1,8 +1,6 @@
 /**
  * A CQL query box with autocomplete.
  * See grammars/querylanguage.pegjs for examples of queries this supports.
- *
- * @jsx React.DOM
  */
 'use strict';
 

--- a/cycledash/static/js/examine/components/StatsSummary.js
+++ b/cycledash/static/js/examine/components/StatsSummary.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var _ = require('underscore'),

--- a/cycledash/static/js/examine/components/VCFTable.js
+++ b/cycledash/static/js/examine/components/VCFTable.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 'use strict';
 
 var _ = require('underscore'),

--- a/cycledash/static/js/examine/components/types.js
+++ b/cycledash/static/js/examine/components/types.js
@@ -1,4 +1,3 @@
-/** @jsx */
 'use strict';
 var React = require('react/addons');
 

--- a/cycledash/static/js/examine/examine.js
+++ b/cycledash/static/js/examine/examine.js
@@ -1,4 +1,3 @@
-/** @jsx React.DOM */
 "use strict";
 
 var React = require('react'),
@@ -12,8 +11,8 @@ window.renderExaminePage = function(el, run, igvHttpfsUrl) {
   var dispatcher = new Dispatcher();
   var recordActions = getRecordActions(dispatcher);
   var recordStore = createRecordStore(run.id, dispatcher);
-  React.renderComponent(<ExaminePage recordStore={recordStore}
-                                     recordActions={recordActions}
-                                     run={run}
-                                     igvHttpfsUrl={igvHttpfsUrl} />, el);
+  React.render(<ExaminePage recordStore={recordStore}
+                            recordActions={recordActions}
+                            run={run}
+                            igvHttpfsUrl={igvHttpfsUrl} />, el);
 };

--- a/cycledash/static/js/examine/utils.js
+++ b/cycledash/static/js/examine/utils.js
@@ -1,4 +1,3 @@
-/** @jsx */
 "use strict";
 
 var _ = require('underscore');

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "idiogrammatik.js": "^1.1.2",
     "jquery": "^2.1.1",
     "jquery-mousewheel": "^3.1.12",
-    "react": "^0.11.2",
+    "react": "^0.12.1",
     "underscore": "^1.7.0"
   },
   "devDependencies": {
@@ -30,8 +30,8 @@
     "mocha-lcov-reporter": "0.0.1",
     "pegjs": "^0.8.0",
     "process": "^0.9.0",
-    "react-tools": "^0.11.1",
-    "reactify": "^0.14.0",
+    "react-tools": "^0.12.1",
+    "reactify": "^0.17.1",
     "sinon": "^1.11.1",
     "typeahead.js": "^0.10.5",
     "uglifyify": "^2.5.0",

--- a/preprocessor.js
+++ b/preprocessor.js
@@ -1,7 +1,0 @@
-// preprocessor.js
-var ReactTools = require('react-tools');
-module.exports = {
-  process: function(src) {
-    return ReactTools.transform(src, {harmony:true});
-  }
-};

--- a/tests/js/jsx-stub-transformer.js
+++ b/tests/js/jsx-stub-transformer.js
@@ -24,18 +24,14 @@ function shouldStub(filename) {
   return false;
 }
 
-// Returns transformed JS if transformation was necessary, otherwise null.
+// Returns transformed JS.
 function transform(filename) {
   if (shouldStub(filename)) {
     return reactStub;
   }
 
   var content = fs.readFileSync(filename, 'utf8');
-  if (content.indexOf('@jsx') > 0) {
-    return ReactTools.transform(content, {harmony: true});
-  } else {
-    return null;
-  }
+  return ReactTools.transform(content, {harmony: true});
 }
 
 // Implements the node.js "compiler" API


### PR DESCRIPTION
Remove @jsx pragmas (not necessary anymore) and use `render` in lieu of
renderComponent (which is being deprecated).

fixes #207

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/289)

<!-- Reviewable:end -->
