### PR TITLE
Only post coverage data while running under Travis

### DIFF
--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -13,5 +13,6 @@ echo 'Linting...'
 ./scripts/lint.sh
 
 if [ $CI ]; then
+  set +o errexit
   ./scripts/travis-coverage.sh
 fi


### PR DESCRIPTION
Fixes #326 
Fixes #327 

See [list of environment variables](http://docs.travis-ci.com/user/ci-environment/#Environment-variables) set on Travis-CI.

The upshot of this is that you can run `./scripts/travis-test.sh` on your local machine to check for problems before sending out a PR.
