### PR TITLE
Update extant_columns in the genotype_extractor

### DIFF
--- a/workers/genotype_extractor.py
+++ b/workers/genotype_extractor.py
@@ -34,6 +34,8 @@ def extract(run):
 
     vcf_id = insert_run(run, engine, connection, metadata)
 
+    update_extant_columns(metadata, connection, vcf_id)
+
     connection.close()
     return vcf_id
 


### PR DESCRIPTION
Otherwise we may wait a LONG (10s of minutes) time to be able to
/examine a run if the gene_annotator must run first.

NB: This doesn't fix the issue on deployed CycleDash--that was resolved by pulling from master & restarting the workers.
