### PR TITLE
Some CSS fixes

### DIFF
--- a/cycledash/static/css/examine.css
+++ b/cycledash/static/css/examine.css
@@ -20,35 +20,41 @@ body {
 .vcf-table {
   padding-top: 20px;
 }
-th {
+.vcf-table th {
   font-size: 19px;
   position: relative;
   white-space: nowrap;
 }
-th.arrow, td.arrow {
+.vcf-table th.arrow,
+.vcf-table td.arrow {
   width: 20px;
   max-width: 20px;
   padding: 0;
   margin: 0;
 }
-th.ref, td.ref, th.alt, td.alt {
+.vcf-table th.ref,
+.vcf-table td.ref,
+.vcf-table th.alt,
+.vcf-table td.alt {
   width: 100px;
   max-width: 100px;
   overflow: hidden;
   text-overflow: ellipsis;
 }
-th.tag {
+.vcf-table th.tag {
   width: 5px;
 }
-th.ref, td.ref {
+.vcf-table th.ref,
+.vcf-table td.ref {
   padding-right: 0;
   text-align: right;
 }
-th.alt, td.alt {
+.vcf-table th.alt,
+.vcf-table td.alt {
   padding-left: 0;
   text-align: left;
 }
-th.uber-column {
+.vcf-table th.uber-column {
   border-left: 1px solid #bbb;
 }
 .vcf-table .tooltip {
@@ -158,35 +164,35 @@ th.uber-column {
 .vcf-table tr.selected {
   background: rgb(254, 255, 207);
 }
-th .sort {
+.vcf-table th .sort {
   cursor: pointer;
 }
-th .sort:before {
+.vcf-table th .sort:before {
   content: ' ↕';
 }
-th .sorting-by.asc:before {
+.vcf-table th .sorting-by.asc:before {
   content: ' ↑';
 }
-th .sorting-by.desc:before {
+.vcf-table th .sorting-by.desc:before {
   content: ' ↓';
 }
-td.pos {
+.vcf-table td.pos {
   font-family: "inconsolata", monospace;
 }
-td.has-comment {
+.vcf-table td.has-comment {
   background: url(/static/img/speech-bubble-noun_5483.svg) no-repeat 11px 2px;
   background-size: 15px 15px;
 }
-td, th {
+.vcf-table td, .vcf-table th {
   text-align: center;
   padding: 3px 13px;
 }
-td {
+.vcf-table td {
   border: none;
   font-size: 13px;
   white-space: nowrap;
 }
-table {
+table.vcf-table {
   border-collapse: collapse;
   width: 100%;
 }
@@ -202,6 +208,20 @@ table {
   border: 1px solid #B6B6B7;
   margin-top: -17px;
   padding: 13px 0px;
+}
+#stats-container table {
+  border-collapse: collapse;
+  width: 100%;
+  border: none;
+  font-size: 13px;
+  white-space: nowrap;
+}
+#stats-container td {
+  text-align: center;
+  padding: 3px 13px;
+}
+#stats-container td.label {
+  padding: .2em .6em .3em  /* from bootstrap */
 }
 #stats-container .precision-recall .label {
   display: table-cell; /* This is needed to override Bootstrap. */

--- a/cycledash/static/css/runs.css
+++ b/cycledash/static/css/runs.css
@@ -43,6 +43,10 @@ td span.run-id {
   font-size: 0.92em;
 }
 
+.runs .run-id, .runs .date {
+  white-space: nowrap;
+}
+
 /* drag and drop file upload */
 .receiving-drag {
   background: rgb(247, 252, 253);

--- a/cycledash/templates/runs.html
+++ b/cycledash/templates/runs.html
@@ -56,23 +56,23 @@
     <thead>
       <tr>
         <th></th>
-        <th>Caller Name</th>
-        <th>Dataset</th>
-        <th>Submitted On</th>
+        <th class="caller-name">Caller Name</th>
+        <th class="dataset">Dataset</th>
+        <th class="date">Submitted On</th>
         <th></th>
       </tr>
     </thead>
     <tbody>
       {%- for run in runs %}
       <tr class="run" data-runId="{{ run['id'] }}">
-        <td>
+        <td class="run-id">
           <span class="run-id">{{ run['id'] }}</span>
           <a class="btn btn-default btn-xs" href="/runs/{{ run['id'] }}/examine">Examine</a>
         </td>
-        <td>{{ run['caller_name'] }}</td>
-        <td>{{ run['dataset_name'] }}</td>
-        <td title="{{ run['created_at'] }}">{{ run['created_at'].strftime('%Y-%m-%d') }}</td>
-        <td>
+        <td class="caller-name">{{ run['caller_name'] }}</td>
+        <td class="dataset">{{ run['dataset_name'] }}</td>
+        <td class="date" title="{{ run['created_at'] }}">{{ run['created_at'].strftime('%Y-%m-%d') }}</td>
+        <td class="labels">
           {%- if run['validation_vcf'] %}<span class="label label-info" title="Is a validation VCF">validation</span>{% endif -%}
           {%- if run['tumor_bam_uri'] %}<span class="label label-info" title="Has an associated tumor BAM">tumor</span>{% endif -%}
           {%- if run['normal_bam_uri'] %}<span class="label label-info" title="Has an associated normal BAM">normal</span>{% endif -%}


### PR DESCRIPTION
This tightens over-broad rules which were affecting `<table>`s they weren't meant to (see #413).
It also makes the Runs table more careful about what wraps when space is limited.

Before:
![screen shot 2015-01-12 at 5 18 03 pm](https://cloud.githubusercontent.com/assets/98301/5712336/6d29d7c8-9a7f-11e4-91ab-1c18cf6252f6.png)

After:
![screen shot 2015-01-12 at 5 18 23 pm](https://cloud.githubusercontent.com/assets/98301/5712337/6f2f3b6c-9a7f-11e4-8c76-42cd764688a3.png)

I made whatever CSS changes were necessary to avoid dpxdt diffs (i.e. to make this a visual no-op). We can tweak the styles if we like.

Fixes #388
Fixes #413 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/419)
<!-- Reviewable:end -->
