### PR TITLE
Fix a comment bubble alignment issue

### DIFF
--- a/cycledash/static/css/runs.css
+++ b/cycledash/static/css/runs.css
@@ -54,6 +54,7 @@ span.no-comment {
 }
 td.comments {
   text-align: right;
+  white-space: nowrap;
 }
 
 .runs .run-id, .runs .date {


### PR DESCRIPTION
Fixing this:

![image](https://cloud.githubusercontent.com/assets/322932/5750557/a8101982-9c24-11e4-8210-61a302a5fb02.png)

It (the comment bubble getting separated from the comment count) happens when caller names get too long. I decided not to include a test for the case where the comment bubble overflows (caller name too long), but I could be convinced otherwise.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/423)
<!-- Reviewable:end -->
