### PR TITLE
Contigs are sorted correctly in genotypes.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,6 @@ voluptuous==0.8.5
 wsgiref==0.1.2
 dpxdt==0.1.5
 psycopg2==2.5.4
-pylint==1.4.0
+pylint==1.4.1
 humanize==0.5.1
 git+git://github.com/hammerlab/pyensembl


### PR DESCRIPTION
Sort contigs first by number, then length, then lexicographically

Fixes #407

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/434)
<!-- Reviewable:end -->
