### PR TITLE
Switch to Travis container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false  # Use container-based infrastructure
 language: python
 python:
   - "2.7"


### PR DESCRIPTION
See [this post][1] and [the docs][2]. This should immediately make our tests start faster and run more quickly. And it should enable [caching][3] down the road if we want to use it.

[1]: http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/
[2]: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
[3]: http://docs.travis-ci.com/user/caching/

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/446)
<!-- Reviewable:end -->
