### PR TITLE
Organize runs page by project

### DIFF
--- a/cycledash/static/css/runs.css
+++ b/cycledash/static/css/runs.css
@@ -20,6 +20,25 @@ form#submit .form-control::-moz-placeholder {
   float: right;
 }
 
+/* Projects  */
+div.project-header h2 {
+  margin: 0;
+}
+div.project-header div.project-stats {
+  font-size: 1.2em;
+  float: right;
+  top: -15px;
+  color: #9d9d9d;
+}
+div.project {
+  margin: 77px 0;
+}
+div.project tbody {
+  height: 100px;
+  width: 500px;
+  overflow: auto;
+}
+
 /* Last comments list: */
 div.comments {
   margin: 29px 0;
@@ -30,6 +49,11 @@ h4.last-comments {
 a.all-comments {
   font-size: 14px;
   color: #adadad;
+}
+
+/* LastComments */
+div.comments {
+  margin-left: 11px;
 }
 
 /* Runs table: */


### PR DESCRIPTION
The projects are sorted so that the project with the most recent run is
at the top, and the runs are sorted by most recent at the top within
each project.

This is the first step to reorganizing the runs page, and one that
requires no changes to the database.

![](https://s3.amazonaws.com/f.cl.ly/items/0t3W0e1a1S2s260O0L27/Screen%20Shot%202015-02-26%20at%205.37.04%20PM.png)

fixes #467 

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/472)

<!-- Reviewable:end -->
