### PR TITLE
Allow "chr" prefix in contig names

### DIFF
--- a/grammars/querylanguage.pegjs
+++ b/grammars/querylanguage.pegjs
@@ -68,7 +68,7 @@ range "range"
     { return { type: 'range', contig: contig, range: range } }
 
 contig
-  = chars:[0-9]+  { return chars.join('') }
+  = chr:"chr"i? chars:[0-9]+  { return (chr || '') + chars.join('') }
   / "X"
   / "Y"
 

--- a/tests/js/query-test.js
+++ b/tests/js/query-test.js
@@ -36,6 +36,7 @@ describe('Query Language', function() {
       expectParse('20:1234-', {range: {contig: '20', start: '1234'}});
       expectParse('20:-4,567', {range: {contig: '20', end: '4567'}});
       expectParse('X:345-4,567', {range: {contig: 'X', start: '345', end: '4567'}});
+      expectParse('chr12:1234-4,567', {range: {contig: 'chr12', start: '1234', end: '4567'}});
     });
 
     it('should parse simple order bys', function() {


### PR DESCRIPTION
This is admittedly a bit of a hack, but allowing more general contig names (e.g. `[a-z0-9]+`) messes with completion.

Fixes #258 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/491)
<!-- Reviewable:end -->
