### PR TITLE
Put CQL queries in the URL, not JSON

### DIFF
--- a/cycledash/comments.py
+++ b/cycledash/comments.py
@@ -15,7 +15,7 @@ def get_all_comments():
     with tables(db, 'user_comments') as (con, user_comments):
         q = select(user_comments.c).order_by(
             desc(user_comments.c.last_modified))
-        comments = [dict(c) for c in con.execute(q).fetchall()]
+        return [dict(c) for c in con.execute(q).fetchall()]
 
 
 def user_comments_db(f=None, use_transaction=False):

--- a/cycledash/genotypes.py
+++ b/cycledash/genotypes.py
@@ -274,18 +274,16 @@ def _add_filter(sql_query, table, column_name, column_type, value, op_name):
     col = column(column_name)
     if table.c.get(column_name) is not None:
         col = cast(table.c[column_name], sqla_type)
-    return {
-        '=': sql_query.where(col == value),
-        '!=': sql_query.where(col != value),
-        '<': sql_query.where(col < value),
-        '>': sql_query.where(col > value),
-        '>=': sql_query.where(col >= value),
-        '<=': sql_query.where(col <= value),
-        'NULL': sql_query.where(col != None),
-        'NOT NULL': sql_query.where(col == None),
-        'LIKE': sql_query.where(col.like(value)),
-        'RLIKE': sql_query.where(col.op('~*')(value))
-    }.get(op_name)
+    if op_name == '=':    return sql_query.where(col == value)
+    elif op_name == '!=': return sql_query.where(col != value)
+    elif op_name == '<':  return sql_query.where(col < value)
+    elif op_name == '>':  return sql_query.where(col > value)
+    elif op_name == '>=': return sql_query.where(col >= value)
+    elif op_name == '<=': return sql_query.where(col <= value)
+    elif op_name == 'NULL': return sql_query.where(col == None)
+    elif op_name == 'NOT NULL': return sql_query.where(col != None)
+    elif op_name == 'LIKE': return sql_query.where(col.like(value))
+    elif op_name == 'RLIKE': return sql_query.where(col.op('~*')(value))
 
 
 def _add_range(sql_query, table, rangeq):

--- a/cycledash/static/js/QueryLanguage.js
+++ b/cycledash/static/js/QueryLanguage.js
@@ -140,7 +140,7 @@ function toString(parsedQuery) {
   // e.g. {filters:[{type: '<', filterValue:'10', columnName:'A'}]}
   if (parsedQuery.filters) {
     filters = filters.concat(parsedQuery.filters.map(f => {
-      if (f.filterValue != null) {
+      if (f.filterValue !== null && f.filterValue !== undefined) {
         return `${f.columnName} ${f.type} ${maybeQuote(f.filterValue)}`;
       } else {
         return `${f.columnName} IS ${f.type}`;

--- a/cycledash/static/js/QueryLanguage.js
+++ b/cycledash/static/js/QueryLanguage.js
@@ -140,10 +140,11 @@ function toString(parsedQuery) {
   // e.g. {filters:[{type: '<', filterValue:'10', columnName:'A'}]}
   if (parsedQuery.filters) {
     filters = filters.concat(parsedQuery.filters.map(f => {
-      if (f.filterValue !== null && f.filterValue !== undefined) {
-        return `${f.columnName} ${f.type} ${maybeQuote(f.filterValue)}`;
-      } else {
+      var type = f.type.toLowerCase();
+      if (type == 'null' || type == 'not null') {
         return `${f.columnName} IS ${f.type}`;
+      } else {
+        return `${f.columnName} ${f.type} ${maybeQuote(f.filterValue)}`;
       }
     }));
   }

--- a/cycledash/static/js/QueryLanguage.js
+++ b/cycledash/static/js/QueryLanguage.js
@@ -139,8 +139,13 @@ function toString(parsedQuery) {
 
   // e.g. {filters:[{type: '<', filterValue:'10', columnName:'A'}]}
   if (parsedQuery.filters) {
-    filters = filters.concat(parsedQuery.filters.map(
-        f => `${f.columnName} ${f.type} ${maybeQuote(f.filterValue)}`));
+    filters = filters.concat(parsedQuery.filters.map(f => {
+      if (f.filterValue != null) {
+        return `${f.columnName} ${f.type} ${maybeQuote(f.filterValue)}`;
+      } else {
+        return `${f.columnName} IS ${f.type}`;
+      }
+    }));
   }
 
   // e.g. {sortBy: [{"columnName": "sample:DP", "order": "desc"}]}

--- a/cycledash/static/js/examine/RecordStore.js
+++ b/cycledash/static/js/examine/RecordStore.js
@@ -12,6 +12,7 @@
 
 var _ = require('underscore'),
     utils = require('./utils'),
+    QueryLanguage = require('../QueryLanguage'),
     $ = require('jquery'),
     ACTION_TYPES = require('./RecordActions').ACTION_TYPES,
     types = require('./components/types');
@@ -357,7 +358,8 @@ function createRecordStore(run, igvHttpfsUrl, dispatcher, opt_testDataSource) {
   }
 
   function setSearchStringToQuery(query) {
-    var queryString = encodeURIComponent(JSON.stringify(query));
+    var queryString = encodeURIComponent(QueryLanguage.toString(query));
+    console.log(QueryLanguage.toString(query));
     window.history.replaceState(null, null, '?query=' + queryString);
   }
 
@@ -369,7 +371,11 @@ function createRecordStore(run, igvHttpfsUrl, dispatcher, opt_testDataSource) {
       var [key, val] = v.split('=');
       return decodeURIComponent(key) == name;
     }));
-    if (val) return decodeURIComponent(val.split('=')[1]);
+    if (val) {
+      var cqlQuery = decodeURIComponent(val.split('=')[1]);
+      return QueryLanguage.parse(cqlQuery);
+    }
+    return null;
   }
 
   /**

--- a/cycledash/static/js/examine/components/QueryBox.js
+++ b/cycledash/static/js/examine/components/QueryBox.js
@@ -8,6 +8,7 @@ var _ = require('underscore'),
     React = require('react'),
     QueryLanguage = require('../../QueryLanguage'),
     QueryCompletion = require('../../QueryCompletion'),
+    utils = require('../utils'),
     $ = require('jquery');
 
 // Hack to make typeahead.js use the correct jQuery.
@@ -19,15 +20,6 @@ var _ = require('underscore'),
   require('typeahead.js');
   window.jQuery = oldJQuery;
 })();
-
-// Extracts a flat list of column names from the uber-columns object
-function extractFlatColumnList(columns) {
-  // columns looks something like {SAMPLE: {DP: {columnName: ...}}}
-  var samples = _.values(columns);
-  var columnInfos = _.flatten(samples.map(_.values));
-  var columnNames = _.pluck(columnInfos, 'columnName');
-  return ['reference', 'alternates', 'contig', 'position'].concat(columnNames);
-}
 
 var QueryBox = React.createClass({
   propTypes: {
@@ -41,7 +33,7 @@ var QueryBox = React.createClass({
     errorMessage: null  // null = no error
   }),
   parseQuery: function(queryStr) {
-    var columnNames = extractFlatColumnList(this.props.columns);
+    var columnNames = utils.extractFlatColumnList(this.props.columns);
     return QueryLanguage.parse(queryStr, columnNames);
   },
   parseAndUpdate: function(queryStr) {
@@ -68,7 +60,7 @@ var QueryBox = React.createClass({
       this.parseAndUpdate($input.val());
     };
     var completionSource = QueryCompletion.createTypeaheadSource(
-        QueryLanguage.parse, extractFlatColumnList(this.props.columns));
+        QueryLanguage.parse, utils.extractFlatColumnList(this.props.columns));
 
     $input
       .typeahead({

--- a/cycledash/static/js/examine/utils.js
+++ b/cycledash/static/js/examine/utils.js
@@ -47,4 +47,17 @@ function makeIGVLink(run, igvHttpfsUrl) {
 }
 
 
-module.exports = { getIn, juxt, makeIGVLink };
+/**
+ * Extracts a flat list of column names from the uber-columns object.
+ * This can be used as a list of CQL column names.
+ */
+function extractFlatColumnList(columns) {
+  // columns looks something like {SAMPLE: {DP: {columnName: ...}}}
+  var samples = _.values(columns);
+  var columnInfos = _.flatten(samples.map(_.values));
+  var columnNames = _.pluck(columnInfos, 'columnName');
+  return ['reference', 'alternates', 'contig', 'position'].concat(columnNames);
+}
+
+
+module.exports = { getIn, juxt, makeIGVLink, extractFlatColumnList };

--- a/tests/js/query-test.js
+++ b/tests/js/query-test.js
@@ -166,6 +166,11 @@ describe('Query Language', function() {
       assert.equal(toString(makeFilter(`A\\"'B\\'"C`)), `A > 'A\\\\"\\'B\\\\\\'"C'`);
     });
 
+    it('should serialize not null', function() {
+      assert.equal(toString({filters:[{type: 'NOT NULL', columnName: 'A'}]}),
+                   'A IS NOT NULL');
+    });
+
     it('should be the inverse of parse()', function() {
       var columns = ['A', 'B', 'INFO.DP', 'annotations:gene_name'];
       var assertInverse = function(str) {
@@ -183,6 +188,7 @@ describe('Query Language', function() {
       assertInverse(`20:-123 AND A <= 0 ORDER BY B DESC, INFO.DP`);
       assertInverse(`20:123- AND A <= 0 ORDER BY B DESC, INFO.DP`);
       assertInverse(`X:123-456 AND A <= 0 ORDER BY B DESC, INFO.DP`);
+      assertInverse(`annotations:gene_name IS NOT NULL`);
     });
   });
 

--- a/tests/pdifftests/test.yaml
+++ b/tests/pdifftests/test.yaml
@@ -49,7 +49,8 @@ tests:
 
   - name: examine-filter
     description: Examine page showing a filtered view
-    url: http://localhost:5001/runs/1/examine?query=%7B%22range%22%3A%7B%22start%22%3Anull%2C%22end%22%3Anull%2C%22contig%22%3Anull%7D%2C%22filters%22%3A%5B%7B%22filterValue%22%3A%22NORMAL%22%2C%22columnName%22%3A%22sample_name%22%2C%22type%22%3A%22%3D%22%7D%2C%7B%22filterValue%22%3A%2250%22%2C%22columnName%22%3A%22info%3ADP%22%2C%22type%22%3A%22%3E%22%7D%5D%2C%22sortBy%22%3A%5B%7B%22order%22%3A%22asc%22%2C%22columnName%22%3A%22info%3ADP%22%7D%2C%7B%22order%22%3A%22desc%22%2C%22columnName%22%3A%22sample%3ARD%22%7D%5D%2C%22page%22%3A0%2C%22limit%22%3A250%7D
+    # CQL: sample_name = NORMAL AND info:DP > 50 ORDER BY info:DP, sample:RD DESC
+    url: http://localhost:5001/runs/1/examine?query=sample_name+%3D+NORMAL+AND+info%3ADP+%3E+50+ORDER+BY+info%3ADP%2C+sample%3ARD+DESC
     config:
       <<: *std-config
 
@@ -116,7 +117,8 @@ tests:
 
   - name: validated-run-with-filter
     description: Same as "validated-run", but with a filter applied.
-    url: http://localhost:5001/runs/2/examine?query=%7B%22range%22%3A%7B%22start%22%3Anull%2C%22end%22%3Anull%2C%22contig%22%3Anull%7D%2C%22filters%22%3A%5B%7B%22filterValue%22%3A%22G%22%2C%22columnName%22%3A%22reference%22%2C%22type%22%3A%22%3D%22%7D%5D%2C%22sortBy%22%3A%5B%7B%22columnName%22%3A%22contig%22%2C%22order%22%3A%22asc%22%7D%2C%7B%22columnName%22%3A%22position%22%2C%22order%22%3A%22asc%22%7D%5D%2C%22page%22%3A0%2C%22limit%22%3A250%7D
+    # CQL: reference = G ORDER BY contig, position
+    url: http://localhost:5001/runs/2/examine?query=reference+%3D+G+ORDER+BY+contig%2C+position
     config:
       <<: *std-config
 


### PR DESCRIPTION
This results in much cleaner URLs (see `test.yaml` for before/after).

This also fixes a few scary bugs:

- `get_all_comments` always returned `None`
- The behavior of `NULL` and `NOT NULL` was reversed.
- `_add_filter` constructed all possible operators, then threw all but one away. This wouldn't work for null checks, since `x > NULL` is invalid SQL.
- `toString()` was broken for queries involving null checks

One thing to note: this parses the query and then sets the URL parameter by re-serializing it to CQL. A simpler approach might be to store the raw CQL query in the URL box, but this would involve threading that through the `RecordStore`. I'm open to suggestions.

Fixes #495 
Fixes #304 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/497)
<!-- Reviewable:end -->
