### PR TITLE
Alter UI for first/subsequent IGV clicks

### DIFF
--- a/cycledash/static/js/examine/components/VCFTable.js
+++ b/cycledash/static/js/examine/components/VCFTable.js
@@ -370,7 +370,7 @@ var VCFCommentBox = React.createClass({
   propTypes: {
     record: React.PropTypes.object.isRequired,
     igvLink: React.PropTypes.string,
-    hasOpenedIGV: React.PropTypes.bool,
+    hasOpenedIGV: React.PropTypes.bool.isRequired,
     didClickIGVLink: React.PropTypes.func.isRequired,
     handleOpenViewer: React.PropTypes.func.isRequired,
     handleSetComment: React.PropTypes.func.isRequired,
@@ -434,7 +434,7 @@ var VCFComment = React.createClass({
     record: React.PropTypes.object.isRequired,
     commentText: React.PropTypes.string.isRequired,
     igvLink: React.PropTypes.string,
-    hasOpenedIGV: React.PropTypes.bool,
+    hasOpenedIGV: React.PropTypes.bool.isRequired,
     didClickIGVLink: React.PropTypes.func.isRequired,
     handleOpenViewer: React.PropTypes.func.isRequired,
     handleDelete: React.PropTypes.func.isRequired,
@@ -495,7 +495,7 @@ var VCFCommentHeader = React.createClass({
   propTypes: {
     record: React.PropTypes.object.isRequired,
     igvLink: React.PropTypes.string,
-    hasOpenedIGV: React.PropTypes.bool,
+    hasOpenedIGV: React.PropTypes.bool.isRequired,
     didClickIGVLink: React.PropTypes.func.isRequired,
     handleOpenViewer: React.PropTypes.func.isRequired,
     handleEdit: React.PropTypes.func.isRequired,

--- a/cycledash/static/js/examine/components/VCFTable.js
+++ b/cycledash/static/js/examine/components/VCFTable.js
@@ -253,6 +253,10 @@ var VCFTableBody = React.createClass({
       }
     });
   },
+  getInitialState: () => ({hasOpenedIGV: false}),
+  didClickIGVLink: function() {
+    this.setState({hasOpenedIGV: true});
+  },
   componentWillUnmount: function() {
     $(window).off('scroll.vcftable');
     $(this.refs.lazyload.getDOMNode()).off('click');
@@ -276,6 +280,8 @@ var VCFTableBody = React.createClass({
               <VCFCommentBox record={record}
                              key={commentKey}
                              igvLink={this.props.igvLink}
+                             hasOpenedIGV={this.state.hasOpenedIGV}
+                             didClickIGVLink={this.didClickIGVLink}
                              handleOpenViewer={this.props.handleOpenViewer}
                              handleSetComment={this.props.handleSetComment}
                              handleDeleteComment={this.props.handleDeleteComment} />
@@ -364,6 +370,8 @@ var VCFCommentBox = React.createClass({
   propTypes: {
     record: React.PropTypes.object.isRequired,
     igvLink: React.PropTypes.string,
+    hasOpenedIGV: React.PropTypes.bool,
+    didClickIGVLink: React.PropTypes.func.isRequired,
     handleOpenViewer: React.PropTypes.func.isRequired,
     handleSetComment: React.PropTypes.func.isRequired,
     handleDeleteComment: React.PropTypes.func.isRequired
@@ -406,6 +414,8 @@ var VCFCommentBox = React.createClass({
           <VCFComment record={this.props.record}
                       commentText={commentText}
                       igvLink={this.props.igvLink}
+                      hasOpenedIGV={this.props.hasOpenedIGV}
+                      didClickIGVLink={this.props.didClickIGVLink}
                       handleOpenViewer={this.props.handleOpenViewer}
                       handleDelete={this.handleDelete}
                       handleSave={this.handleSave} />
@@ -424,6 +434,8 @@ var VCFComment = React.createClass({
     record: React.PropTypes.object.isRequired,
     commentText: React.PropTypes.string.isRequired,
     igvLink: React.PropTypes.string,
+    hasOpenedIGV: React.PropTypes.bool,
+    didClickIGVLink: React.PropTypes.func.isRequired,
     handleOpenViewer: React.PropTypes.func.isRequired,
     handleDelete: React.PropTypes.func.isRequired,
     handleSave: React.PropTypes.func.isRequired
@@ -464,6 +476,8 @@ var VCFComment = React.createClass({
           <VCFCommentHeader handleEdit={() => {this.setEditState(true);}}
                             record={this.props.record}
                             igvLink={this.props.igvLink}
+                            hasOpenedIGV={this.props.hasOpenedIGV}
+                            didClickIGVLink={this.props.didClickIGVLink}
                             handleOpenViewer={this.props.handleOpenViewer}
                             handleDelete={this.props.handleDelete} />
       );
@@ -481,6 +495,8 @@ var VCFCommentHeader = React.createClass({
   propTypes: {
     record: React.PropTypes.object.isRequired,
     igvLink: React.PropTypes.string,
+    hasOpenedIGV: React.PropTypes.bool,
+    didClickIGVLink: React.PropTypes.func.isRequired,
     handleOpenViewer: React.PropTypes.func.isRequired,
     handleEdit: React.PropTypes.func.isRequired,
     handleDelete: React.PropTypes.func.isRequired
@@ -491,6 +507,14 @@ var VCFCommentHeader = React.createClass({
         loadIGVLink = this.props.igvLink + locusParam,
         jumpLink = loadIGVLink.replace(/\/load.*/, '/goto?') + locusParam;
 
+    // The links are worded differently depending on previous actions.
+    var didClick = this.props.didClickIGVLink;
+    var igvLinks = this.props.hasOpenedIGV ?
+        [<a href={jumpLink} onClick={didClick}>Jump to Locus</a>,
+         <a href={loadIGVLink} onClick={didClick}>(reload)</a>] :
+        [<a href={loadIGVLink} onClick={didClick}>Load at Locus</a>,
+         <a href={jumpLink} onClick={didClick}>(Jump)</a>];
+
     return (
       <div className='comment-header'>
         <a className='dalliance-open'
@@ -498,8 +522,8 @@ var VCFCommentHeader = React.createClass({
           Open Pileup Viewer
         </a>
         <span className='igv-links'>
-          IGV: <a href={loadIGVLink}>Load at Locus</a>&nbsp;
-               <a href={jumpLink}>(Jump)</a>&nbsp;
+          IGV: {igvLinks[0]}&nbsp;
+               {igvLinks[1]}&nbsp;
                <a href="https://github.com/hammerlab/cycledash/wiki/IGV-Integration">help</a>
         </span>
         <button className='btn btn-default btn-xs comment-button btn-danger'


### PR DESCRIPTION
Fixes #479 

UI before any clicks:
![screen shot 2015-03-03 at 12 11 36 pm](https://cloud.githubusercontent.com/assets/98301/6467796/867db0be-c19e-11e4-8695-2424fdef253e.png)

UI after any clicks:
![screen shot 2015-03-03 at 12 11 02 pm](https://cloud.githubusercontent.com/assets/98301/6467798/8a51c5e0-c19e-11e4-920b-725b36dd9c2e.png)

The idea here is to make the first, most prominent link be the one you typically want.

@arahuja @timodonnell @ryan-williams FYI

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/508)
<!-- Reviewable:end -->
