### PR TITLE
More aggressive linting: console and unused vars

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -12,6 +12,7 @@
   "shadow": true,
   "browser": true,
   "mocha": true,
+  "unused": "vars",  // unused vars are bad, but function params are OK
   // allow module-level "use strict", which is OK with browserify.
   "globalstrict": true,
   "globals": {

--- a/.jshintrc
+++ b/.jshintrc
@@ -11,14 +11,20 @@
   "lastsemic": false,
   "shadow": true,
   "browser": true,
-  "node": true,
   "mocha": true,
+  // allow module-level "use strict", which is OK with browserify.
+  "globalstrict": true,
   "globals": {
     "d3": true,
     "_": true,
     "$": true,
     "Browser": true,
-    "React": true
+    "React": true,
+    // We don't set "node: true" to capture certain issues, e.g. console.log
+    // statements. These globals make up for that.
+    "require": true,
+    "module": true,
+    "global": true
   },
   "maxerr": 100000
 }

--- a/cycledash/static/js/QueryCompletion.js
+++ b/cycledash/static/js/QueryCompletion.js
@@ -159,7 +159,7 @@ function getTokenizedCompletions(query, parse, columnNames) {
     } else {
       // Probably an invalid column name. Pop off the last token and try
       // completing column names. Fuzzy matching happens below.
-      var [subquery] = splitLastToken(query);
+      var subquery = splitLastToken(query)[0];
       completions = completions.concat(concatProductOf([subquery], columnNames));
     }
   } else {

--- a/cycledash/static/js/QueryCompletion.js
+++ b/cycledash/static/js/QueryCompletion.js
@@ -159,7 +159,7 @@ function getTokenizedCompletions(query, parse, columnNames) {
     } else {
       // Probably an invalid column name. Pop off the last token and try
       // completing column names. Fuzzy matching happens below.
-      var [subquery, lastToken] = splitLastToken(query);
+      var [subquery] = splitLastToken(query);
       completions = completions.concat(concatProductOf([subquery], columnNames));
     }
   } else {

--- a/cycledash/static/js/examine/RecordStore.js
+++ b/cycledash/static/js/examine/RecordStore.js
@@ -379,7 +379,7 @@ function createRecordStore(run, igvHttpfsUrl, dispatcher, opt_testDataSource) {
     var search = window.location.search.substring(1),
         vars = search.split('&');
     var val = _.first(_.filter(vars, v => {
-      var [key] = v.split('=');
+      var key = v.split('=')[0];
       return decodeURIPlus(key) == name;
     }));
     if (val) {

--- a/cycledash/static/js/examine/RecordStore.js
+++ b/cycledash/static/js/examine/RecordStore.js
@@ -379,7 +379,7 @@ function createRecordStore(run, igvHttpfsUrl, dispatcher, opt_testDataSource) {
     var search = window.location.search.substring(1),
         vars = search.split('&');
     var val = _.first(_.filter(vars, v => {
-      var [key, val] = v.split('=');
+      var [key] = v.split('=');
       return decodeURIPlus(key) == name;
     }));
     if (val) {

--- a/cycledash/static/js/examine/components/BioDalliance.js
+++ b/cycledash/static/js/examine/components/BioDalliance.js
@@ -170,10 +170,10 @@ var BioDalliance = React.createClass({
           .done((chunks) => {
             this.setState(_.object([propName], [chunks]));
           }).fail((jqXHR, error, textStatus) => {
-            if (textStatus != 'Not Found') {
-              console.warn('Invalid bai.json file', chunkPath, error, textStatus);
-            }
             this.setState(_.object([propName], [CHUNKS_NOT_AVAILABLE]));
+            if (textStatus != 'Not Found') {
+              throw `Invalid bai.json file ${chunkPath} ${error} ${textStatus}`;
+            }
           });
       });
   },
@@ -239,10 +239,8 @@ var EventGuardian = function(elementClass, inputEvents) {
 
   this.elementClass_ = elementClass;
   var realListener = this.elementClass_.prototype.addEventListener;
-  console.log('Guarding against', this.elementClass_, events);
   this.elementClass_.prototype.addEventListener = function(name, meth, useCapture) {
     if (events.indexOf(name) >= 0) {
-      console.log('Blocking attempt to listen to', name);
       return;
     }
     return realListener.call(this, name, meth, useCapture);

--- a/cycledash/static/js/examine/components/BioDalliance.js
+++ b/cycledash/static/js/examine/components/BioDalliance.js
@@ -69,16 +69,6 @@ var BioDalliance = React.createClass({
   lazilyCreateDalliance: function() {
     if (this.browser) return;
 
-    // Workaround for https://github.com/dasmoth/dalliance/issues/125
-    var uniquelyNamedBlob = (function() {
-      var id = 0;
-      return function(bytes) {
-        var blob = new Blob([bytes]);
-        blob.name = id++;
-        return blob;
-      };
-    })();
-
     var vcfSource = (name, path) => {
       var source = {
         name: name,
@@ -285,39 +275,6 @@ var bamStyle = [
     "_typeRE": {},
     "_labelRE": {},
     "_methodRE": {}
-  }
-];
-
-
-// Style for visualizing BAM coverage.
-var coverageStyle = [
-  {
-    "type": "density",
-    "zoom": "low",
-    "style": {
-      "glyph": "HISTOGRAM",
-      "COLOR1": "gray",
-      "HEIGHT": 30
-    }
-  },
-  {
-    "type": "density",
-    "zoom": "medium",
-    "style": {
-      "glyph": "HISTOGRAM",
-      "COLOR1": "gray",
-      "HEIGHT": 30
-    }
-  },
-  {
-    "type": "base-coverage",
-    "zoom": "high",
-    "style": {
-      "glyph": "HISTOGRAM",
-      "COLOR1": "lightgray",
-      "BGITEM": true,
-      "HEIGHT": 30
-    }
   }
 ];
 

--- a/cycledash/static/js/examine/components/CommentBox.js
+++ b/cycledash/static/js/examine/components/CommentBox.js
@@ -9,10 +9,7 @@
 
 var _ = require('underscore'),
     React = require('react/addons'),
-    types = require('./types'),
-    $ = require('jquery'),
-    marked = require('marked'),
-    utils = require('../utils');
+    marked = require('marked');
 
 /**
  * Use markdown for comments, and set appropriate flags to:

--- a/cycledash/static/js/examine/components/Downloads.js
+++ b/cycledash/static/js/examine/components/Downloads.js
@@ -1,9 +1,5 @@
 'use strict';
-var _ = require('underscore'),
-    React = require('react'),
-    QueryLanguage = require('../../QueryLanguage'),
-    $ = require('jquery');
-
+var React = require('react');
 
 var Downloads = React.createClass({
   propTypes: {

--- a/cycledash/static/js/examine/components/ExamineInformation.js
+++ b/cycledash/static/js/examine/components/ExamineInformation.js
@@ -1,7 +1,6 @@
 "use strict";
 
-var _ = require('underscore'),
-    React = require('react/addons');
+var React = require('react/addons');
 
 
 var ExamineInformation = React.createClass({

--- a/cycledash/static/js/examine/components/ExaminePage.js
+++ b/cycledash/static/js/examine/components/ExaminePage.js
@@ -1,8 +1,6 @@
 "use strict";
 
-var _ = require('underscore'),
-    React = require('react'),
-    idiogrammatik = require('idiogrammatik.js'),
+var React = require('react'),
     BioDalliance = require('./BioDalliance'),
     StatsSummary = require('./StatsSummary'),
     VCFTable = require('./VCFTable'),

--- a/cycledash/static/js/examine/components/QueryBox.js
+++ b/cycledash/static/js/examine/components/QueryBox.js
@@ -4,8 +4,7 @@
  */
 'use strict';
 
-var _ = require('underscore'),
-    React = require('react'),
+var React = require('react'),
     QueryLanguage = require('../../QueryLanguage'),
     QueryCompletion = require('../../QueryCompletion'),
     utils = require('../utils'),

--- a/cycledash/static/js/examine/components/VCFTable.js
+++ b/cycledash/static/js/examine/components/VCFTable.js
@@ -340,8 +340,7 @@ var VCFRecord = React.createClass({
         );
       }
     });
-    var recordClasses = React.addons.classSet({selected: this.props.isSelected}),
-        record = this.props.record;
+    var recordClasses = React.addons.classSet({selected: this.props.isSelected});
     return (
       <tr className={recordClasses} onClick={this.handleClick}>
         {tds}

--- a/cycledash/static/js/examine/components/VCFTable.js
+++ b/cycledash/static/js/examine/components/VCFTable.js
@@ -4,8 +4,7 @@ var _ = require('underscore'),
     React = require('react/addons'),
     types = require('./types'),
     $ = require('jquery'),
-    CommentBox = require('./CommentBox'),
-    utils = require('../utils');
+    CommentBox = require('./CommentBox');
 
 var VCFTable = React.createClass({
   propTypes: {

--- a/cycledash/static/js/runs/components/forms.js
+++ b/cycledash/static/js/runs/components/forms.js
@@ -200,9 +200,9 @@ var TextInput = React.createClass({
       .on('load', path => {
         fileInputElement.value = path;
       })
-      .on('error', error => {
-        console.error(error);
+      .on('error', function(error) {
         fileInputElement.value = this._extractError(error);
+        throw error;
       })
       .on('progress', () => {
         var e = d3.event;

--- a/cycledash/static/js/runs/components/forms.js
+++ b/cycledash/static/js/runs/components/forms.js
@@ -199,7 +199,7 @@ var TextInput = React.createClass({
       .on('load', path => {
         fileInputElement.value = path;
       })
-      .on('error', function(error) {
+      .on('error', error => {
         fileInputElement.value = this._extractError(error);
         throw error;
       })

--- a/cycledash/static/js/runs/components/forms.js
+++ b/cycledash/static/js/runs/components/forms.js
@@ -1,7 +1,6 @@
 'use strict';
 var React = require('react'),
     d3 = require('d3'),
-    CompletionUtils = require('../../CompletionUtils'),
     $ = require('jquery');
 
 
@@ -61,7 +60,6 @@ var NewBAMForm = React.createClass({
     projectName: React.PropTypes.string.isRequired
   },
   render: function() {
-    var props = this.props;
     return (
         <form method='POST' action='/bams' className='bam-form'>
         <h3>New BAM</h3>

--- a/cycledash/static/js/runs/components/forms.js
+++ b/cycledash/static/js/runs/components/forms.js
@@ -1,7 +1,6 @@
 'use strict';
 var React = require('react'),
     d3 = require('d3'),
-    _ = require('underscore'),
     CompletionUtils = require('../../CompletionUtils'),
     $ = require('jquery');
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
     "d3": "^3.4.11",
     "dalliance": "danvk/dalliance#dist",
     "flux": "^2.0.1",
-    "idiogrammatik.js": "^1.1.2",
     "jquery": "2.1.1",
     "jquery-mousewheel": "^3.1.12",
     "marked": "^0.3.2",

--- a/tests/js/CommentUtils.js
+++ b/tests/js/CommentUtils.js
@@ -1,8 +1,6 @@
 'use strict';
 var _ = require('underscore'),
     fs = require('fs'),
-    vcf = require('vcf.js'),
-    Utils = require('./Utils'),
     DataUtils = require('./DataUtils');
 
 /**

--- a/tests/js/CompletionUtils-test.js
+++ b/tests/js/CompletionUtils-test.js
@@ -1,12 +1,10 @@
 'use strict';
 
-var _ = require('underscore'),
-    assert = require('assert'),
+var assert = require('assert'),
     CompletionUtils = require('../../cycledash/static/js/CompletionUtils.js');
 
 var {
   cartesianProductOf,
-  flatMap,
   fuzzyMatch,
   splitLastToken,
   tokenize

--- a/tests/js/ExaminePage-comments-test.js
+++ b/tests/js/ExaminePage-comments-test.js
@@ -11,7 +11,6 @@ global.reactModulesToStub = [
 ];
 
 var ExaminePage = require('../../cycledash/static/js/examine/components/ExaminePage'),
-    QueryBox = require('../../cycledash/static/js/examine/components/QueryBox'),
     createRecordStore = require('../../cycledash/static/js/examine/RecordStore'),
     RecordActions = require('../../cycledash/static/js/examine/RecordActions'),
     Dispatcher = require('../../cycledash/static/js/examine/Dispatcher'),
@@ -104,7 +103,7 @@ describe('ExaminePage Comments', function() {
 
   function stubDialogs() {
     // Stub out confirm dialogs.
-    var stub = sinonSandbox.stub(window, 'confirm', _.constant(true));
+    sinonSandbox.stub(window, 'confirm', _.constant(true));
   }
 
   it('should get, modify, create and delete', function() {

--- a/tests/js/ExaminePage-test.js
+++ b/tests/js/ExaminePage-test.js
@@ -4,8 +4,7 @@
 require('./testdom')('<html><body></body></html>');
 var React = require('react/addons'),
     assert = require('assert'),
-    _ = require('underscore'),
-    sinon = require('sinon');
+    _ = require('underscore');
 
 global.reactModulesToStub = [
   'components/BioDalliance.js'

--- a/tests/js/IGVLink-test.js
+++ b/tests/js/IGVLink-test.js
@@ -7,9 +7,7 @@
 require('./testdom')('<html><body></body></html>');
 var React = require('react/addons'),
     assert = require('assert'),
-    _ = require('underscore'),
-    $ = require('jquery'),
-    fs = require('fs');
+    _ = require('underscore');
 
 var CommentBox = require('../../cycledash/static/js/examine/components/CommentBox'),
     TestUtils = React.addons.TestUtils,

--- a/tests/js/blanket-stub-jsx.js
+++ b/tests/js/blanket-stub-jsx.js
@@ -40,7 +40,7 @@ module.exports = function(blanket) {
         instrumented = instrumented.replace(/require\s*\(\s*("|')\./g,'require($1' + baseDirPath);
         localModule._compile(instrumented, normalizedFilename);
       } catch(err){
-        console.log("Error parsing instrumented code: " + err);
+        throw "Error parsing instrumented code: " + err;
       }
     });
   };

--- a/tests/js/blanket-stub-jsx.js
+++ b/tests/js/blanket-stub-jsx.js
@@ -5,8 +5,7 @@
 var fs = require('fs'),
     glob = require('glob'),
     path = require('path'),
-    transformer = require('./jsx-stub-transformer'),
-    ReactTools = require('react-tools');
+    transformer = require('./jsx-stub-transformer');
 
 
 module.exports = function(blanket) {

--- a/tests/js/examine-utils-test.js
+++ b/tests/js/examine-utils-test.js
@@ -1,8 +1,7 @@
 'use strict';
 
 var utils = require('../../cycledash/static/js/examine/utils'),
-    assert = require('assert'),
-    React = require('react/addons');
+    assert = require('assert');
 
 describe('Examine Utils', function() {
   var igvHttpfsUrl = 'http://example.com';

--- a/tests/js/query-completion-test.js
+++ b/tests/js/query-completion-test.js
@@ -1,13 +1,11 @@
 'use strict';
 
-var _ = require('underscore'),
-    assert = require('assert'),
+var assert = require('assert'),
     QueryLanguage = require('../../cycledash/static/js/QueryLanguage.js'),
     QueryCompletion = require('../../cycledash/static/js/QueryCompletion.js');
 
 describe('Query Completion', function() {
   var defaultColumns = ['A', 'B', 'INFO.DP', 'sample:GQ'];
-  var filterPrefix = QueryCompletion.filterPrefix;
 
   // Returns a list of possible complete queries.
   function getCompletions(prefix, columns, position) {

--- a/tests/js/query-test.js
+++ b/tests/js/query-test.js
@@ -1,7 +1,6 @@
 'use strict';
 
-var _ = require('underscore'),
-    assert = require('assert'),
+var assert = require('assert'),
     QueryLanguage = require('../../cycledash/static/js/QueryLanguage.js');
 
 


### PR DESCRIPTION
Fixes #528 

(first commit) The `console.log` statements I'm happy to see go. I converted the others into `throw`. LMK what you think.

(second commit) I've also set `"unused": "vars"`, which warns about unused variables, but not unused function parameters. This helped to eliminate a ton of dead code & unnecessary imports.

 cc @tavinathanson 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/529)
<!-- Reviewable:end -->
