### PR TITLE
Display FILTER & QUAL fields in the table

### DIFF
--- a/cycledash/static/js/examine/components/VCFTable.js
+++ b/cycledash/static/js/examine/components/VCFTable.js
@@ -98,7 +98,9 @@ var VCFTableHeader = React.createClass({
             </th>,
             <th key='ref' className='ref'>REF</th>,
             <th key='arrow' className='arrow'>→</th>,
-            <th key='alt' className='alt'>ALT</th>
+            <th key='alt' className='alt'>ALT</th>,
+            <th key='quality' className='quality'>quality</th>,
+            <th key='filters' className='filters'>filters</th>
         ];
 
     _.each(this.props.columns, (columns, topLevelColumnName) => {
@@ -326,6 +328,12 @@ var VCFRecord = React.createClass({
       <td key='arrow' className='arrow'>→</td>,
       <td key='alt' className='alt' title={this.props.record.alternates}>
         {this.props.record.alternates}
+      </td>,
+      <td key='quality' className='quality' title={this.props.record.quality}>
+        {this.props.record.quality}
+      </td>,
+      <td key='filters' className='filters' title={this.props.record.filters}>
+        {this.props.record.filters}
       </td>
     ];
     _.each(this.props.columns, (columns, topLevelColumnName) => {

--- a/tests/js/ExaminePage-test.js
+++ b/tests/js/ExaminePage-test.js
@@ -101,7 +101,7 @@ describe('ExaminePage', function() {
     // Make sure all 19 columns are here.
     var totalColumns = Utils.findInComponent(
         '.vcf-table thead tr:nth-child(2) th', examine).length;
-    assert.equal(totalColumns, 19);
+    assert.equal(totalColumns, 21);
 
     var columnAttributes = Utils.findInComponent(
         '.vcf-table thead tr:nth-child(2) th', examine).map(function(el) {


### PR DESCRIPTION
Fixes #473 

Pending #538 

![](https://s3.amazonaws.com/f.cl.ly/items/1U3O3V1e1N092P0Y2t1B/Screen%20Shot%202015-03-13%20at%204.25.26%20PM.png)

Unfortunately, I don't have a run with filters in my table, so we see an empty column in the VCF. I'll file an issue for this.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/539)

<!-- Reviewable:end -->
