### PR TITLE
Unify /runs and /examine vcf object

### DIFF
--- a/cycledash/bams.py
+++ b/cycledash/bams.py
@@ -19,14 +19,14 @@ def attach_bams_to_vcfs(vcfs):
     with tables(db, 'bams') as (con, bams):
         q = select(bams.c)
         bams = [dict(b) for b in con.execute(q).fetchall()]
-        for vcf in vcfs:
-            normal_bam_id = vcf.get('normal_bam_id')
-            tumor_bam_id = vcf.get('tumor_bam_id')
+    for vcf in vcfs:
+        normal_bam_id = vcf.get('normal_bam_id')
+        tumor_bam_id = vcf.get('tumor_bam_id')
 
-            vcf['tumor_bam'] = (
-                dict(find(bams, lambda x: x.get('id') == tumor_bam_id) or {}))
-            vcf['normal_bam'] = (
-                dict(find(bams, lambda x: x.get('id') == normal_bam_id) or {}))
+        vcf['tumor_bam'] = (
+            dict(find(bams, lambda x: x.get('id') == tumor_bam_id) or {}))
+        vcf['normal_bam'] = (
+            dict(find(bams, lambda x: x.get('id') == normal_bam_id) or {}))
 
 
 def get_bam(bam_id):

--- a/cycledash/bams.py
+++ b/cycledash/bams.py
@@ -4,7 +4,7 @@ from flask import redirect, jsonify, url_for, request
 from sqlalchemy import exc, select, func, desc
 import voluptuous
 
-from common.helpers import tables
+from common.helpers import tables, find
 import cycledash.validations
 from cycledash import db
 from cycledash.helpers import (prepare_request_data, error_response,
@@ -12,6 +12,21 @@ from cycledash.helpers import (prepare_request_data, error_response,
 import cycledash.projects
 
 import workers.indexer
+
+
+def attach_bams_to_vcfs(vcfs):
+    """Attaches tumor_bam and normal_bam to all the VCFs."""
+    with tables(db, 'bams') as (con, bams):
+        q = select(bams.c)
+        bams = [dict(b) for b in con.execute(q).fetchall()]
+        for vcf in vcfs:
+            normal_bam_id = vcf.get('normal_bam_id')
+            tumor_bam_id = vcf.get('tumor_bam_id')
+
+            vcf['tumor_bam'] = (
+                dict(find(bams, lambda x: x.get('id') == tumor_bam_id) or {}))
+            vcf['normal_bam'] = (
+                dict(find(bams, lambda x: x.get('id') == normal_bam_id) or {}))
 
 
 def get_bam(bam_id):

--- a/cycledash/projects.py
+++ b/cycledash/projects.py
@@ -104,7 +104,7 @@ def set_and_verify_project_id_on(data):
             raise voluptuous.Invalid('no project with id {}'.format(project_id))
 
 
-def _get_projects_tree():
+def get_projects_tree_dict():
     """Return a list of all projects, with their respective vcfs and bams.
 
     { "projects": [
@@ -167,9 +167,9 @@ def _join_task_states(vcfs):
 
 def get_projects_tree():
     if request_wants_json():
-        vcfs = _get_projects_tree()
+        vcfs = get_projects_tree_dict()
         return jsonify({'runs': vcfs})
     elif 'text/html' in request.accept_mimetypes:
-        vcfs = _get_projects_tree()
+        vcfs = get_projects_tree_dict()
         comments = cycledash.comments.get_last_comments()
         return render_template('runs.html', last_comments=comments, runs=vcfs)

--- a/cycledash/static/js/examine/components/ExaminePage.js
+++ b/cycledash/static/js/examine/components/ExaminePage.js
@@ -73,12 +73,14 @@ var ExaminePage = React.createClass({
     this.props.recordActions.deleteComment(comment, record);
   },
   render: function() {
-    var state = this.state, props = this.props;
+    var state = this.state,
+        props = this.props,
+        run = props.vcf;
     return (
       <div className="examine-page">
         <StatsSummary hasLoaded={state.hasLoaded}
                       stats={state.stats} />
-        <ExamineInformation run={props.vcf}/>
+        <ExamineInformation run={run}/>
         {props.comparableVcfs ?
          <VCFValidation vcfs={props.comparableVcfs}
                         selectedVcfId={state.selectedVcfId}
@@ -89,7 +91,7 @@ var ExaminePage = React.createClass({
                   loadError={state.loadError}
                   query={state.query}
                   handleQueryChange={this.handleQueryChange} />
-        <Downloads query={state.query} run_id={props.vcf.id} />
+        <Downloads query={state.query} run_id={run.id} />
         <VCFTable ref="vcfTable"
                   hasLoaded={state.hasLoaded}
                   records={state.records}
@@ -105,9 +107,9 @@ var ExaminePage = React.createClass({
                   handleOpenViewer={this.handleOpenViewer}
                   handleSetComment={this.handleSetComment}
                   handleDeleteComment={this.handleDeleteComment} />
-        <BioDalliance vcfPath={props.vcf.uri}
-                      normalBamPath={props.vcf.normal_bam_uri}
-                      tumorBamPath={props.vcf.tumor_bam_uri}
+        <BioDalliance vcfPath={run.uri}
+                      normalBamPath={run.normal_bam && run.normal_bam.uri}
+                      tumorBamPath={run.tumor_bam && run.tumor_bam.uri}
                       igvHttpfsUrl={props.igvHttpfsUrl}
                       selectedRecord={state.selectedRecord}
                       isOpen={state.isViewerOpen}

--- a/cycledash/views.py
+++ b/cycledash/views.py
@@ -106,15 +106,17 @@ def bam(bam_id):
  ## Examine ##
 #############
 
-@app.route('/runs/<run_id>/examine')
+@app.route('/runs/<int:run_id>/examine')
 def examine(run_id):
     vcf = cycledash.runs.get_vcf(run_id)
+    if not vcf:
+        return error_response('Invalid run', 'Invalid run: %s' % run_id)
     return render_template('examine.html',
                            vcf=vcf,
                            vcfs=cycledash.runs.get_related_vcfs(vcf))
 
 
-@app.route('/runs/<run_id>/genotypes')
+@app.route('/runs/<int:run_id>/genotypes')
 def genotypes(run_id):
     gts = cycledash.genotypes.get(run_id, json.loads(request.args.get('q')))
     return jsonify(gts)
@@ -138,7 +140,7 @@ def comments(vcf_id):
         return cycledash.comments.get_vcf_comments(vcf_id)
 
 
-@app.route('/runs/<run_id>/comments/<comment_id>', methods=['PUT', 'DELETE'])
+@app.route('/runs/<int:run_id>/comments/<comment_id>', methods=['PUT', 'DELETE'])
 def comment(run_id, comment_id):
     if request.method == 'PUT':
         return cycledash.comments.update_comment(comment_id)
@@ -152,7 +154,7 @@ def comment(run_id, comment_id):
 
 VCF_FILENAME = 'cycledash-run-{}.vcf'
 
-@app.route('/runs/<run_id>/download')
+@app.route('/runs/<int:run_id>/download')
 def download_vcf(run_id):
     query = json.loads(request.args.get('query'))
     genotypes = cycledash.genotypes.genotypes_for_records(run_id, query)


### PR DESCRIPTION
See #574 

Previously the `vcf` object on the /examine page only had tumor_bam_id and not tumor_bam_uri. There were a few other subtle distinctions between the examine page's `vcf` object and the equivalent on the runs page.

This results in more work being done on the initial /examine request, but it's an exact copy of the /runs request, so hopefully it's not a big deal.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/591)
<!-- Reviewable:end -->
