### PR TITLE
Set Sass livereload to auto:false to prevent failing tests

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -58,7 +58,8 @@ gulp.task('js', function() {
 gulp.task('sass', function () {
     gulp.src('./cycledash/static/scss/*.scss')
         .pipe(sass().on('error', sass.logError))
-        .pipe(gulp.dest('./cycledash/static/css'));
+        .pipe(gulp.dest('./cycledash/static/css'))
+        .pipe(livereload({ auto: false }));
 });
 
 // Starts the livereload server and runs the 'js' and 'sass' tasks, above.


### PR DESCRIPTION
`gulp sass` will terminate when livereload is set to auto:false in the sass gulp task.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/599)

<!-- Reviewable:end -->
