### PR TITLE
Style refactor

### DIFF
--- a/cycledash/static/scss/examine.scss
+++ b/cycledash/static/scss/examine.scss
@@ -1,4 +1,4 @@
-@import 'bootstrap.min';
+@import 'style';
 
 /* ExaminePage */
 h1 small {

--- a/cycledash/static/scss/examine.scss
+++ b/cycledash/static/scss/examine.scss
@@ -1,3 +1,5 @@
+@import 'bootstrap.min';
+
 /* ExaminePage */
 h1 small {
   font-size: 17px;

--- a/cycledash/static/scss/header.scss
+++ b/cycledash/static/scss/header.scss
@@ -1,3 +1,5 @@
+@import 'bootstrap.min';
+
 nav.navigation {
   font-size: 12px;
   position: absolute;

--- a/cycledash/static/scss/header.scss
+++ b/cycledash/static/scss/header.scss
@@ -1,5 +1,3 @@
-@import 'bootstrap.min';
-
 nav.navigation {
   font-size: 12px;
   position: absolute;

--- a/cycledash/static/scss/runs.scss
+++ b/cycledash/static/scss/runs.scss
@@ -1,4 +1,4 @@
-@import 'bootstrap.min';
+@import 'style';
 
 main {
   width: 800px;

--- a/cycledash/static/scss/runs.scss
+++ b/cycledash/static/scss/runs.scss
@@ -1,3 +1,5 @@
+@import 'bootstrap.min';
+
 main {
   width: 800px;
   margin: auto;

--- a/cycledash/static/scss/style.scss
+++ b/cycledash/static/scss/style.scss
@@ -1,4 +1,4 @@
-@import 'bootstrap.min';
+@import '../lib/bootstrap/scss/bootstrap';
 @import 'header';
 
 body {

--- a/cycledash/static/scss/style.scss
+++ b/cycledash/static/scss/style.scss
@@ -1,4 +1,5 @@
 @import 'bootstrap.min';
+@import 'header';
 
 body {
   padding: 11px;

--- a/cycledash/static/scss/style.scss
+++ b/cycledash/static/scss/style.scss
@@ -1,3 +1,5 @@
+@import 'bootstrap.min';
+
 body {
   padding: 11px;
   font-family: "freight-sans-pro", verdana, helvetica, sans-serif;

--- a/cycledash/templates/about.html
+++ b/cycledash/templates/about.html
@@ -1,6 +1,10 @@
 {% extends "layouts/layout.html" %}
 {%- from 'macros/nav.html' import nav -%}
 
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+{% endblock %}
+
 {% block body %}
 {{ nav("about") }}
 <main>

--- a/cycledash/templates/comments.html
+++ b/cycledash/templates/comments.html
@@ -1,6 +1,10 @@
 {% extends "layouts/layout.html" %}
 {%- from 'macros/nav.html' import nav -%}
 
+{% block head %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+{% endblock %}
+
 {% block body %}
 {{ nav("comments") }}
 <main id="comments"></main>

--- a/cycledash/templates/layouts/layout.html
+++ b/cycledash/templates/layouts/layout.html
@@ -12,7 +12,6 @@
 
     {% block bootstrap %}
     <script src="/static/lib/bootstrap/js/bootstrap.min.js"></script>
-    <link rel="stylesheet" href="/static/lib/bootstrap/css/bootstrap.min.css">
     {% endblock %}
 
     {% if config['USE_RELOADER'] %}

--- a/cycledash/templates/layouts/layout.html
+++ b/cycledash/templates/layouts/layout.html
@@ -29,9 +29,6 @@
     <script type="text/javascript" src={{config['TYPEKIT_URL']}}></script>
     <script type="text/javascript">try{Typekit.load();}catch(e){}</script>
     {% endif %}
-
-    <link rel="stylesheet" href="/static/css/style.css">
-    <link rel="stylesheet" href="/static/css/header.css">
     {% block head %}{% endblock %}
   </head>
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,8 @@ var _ = require('underscore'),
     source = require('vinyl-source-stream'),
     uglifyify = require('uglifyify'),
     watchify = require('watchify'),
-    sass = require('gulp-sass');
+    sass = require('gulp-sass'),
+    ext_replace = require('gulp-ext-replace');
 
 
 var PATHS = {
@@ -100,6 +101,11 @@ gulp.task('staticlibs', function() {
            {base: './node_modules/bootstrap/dist'})
     .pipe(gulp.dest('./cycledash/static/lib/bootstrap'));
 
+  // Change bootstrap.min.css to bootstrap.min.scss
+  gulp.src('./cycledash/static/lib/bootstrap/css/bootstrap.min.css')
+    .pipe(ext_replace('.scss', '.min.css'))
+    .pipe(gulp.dest('./cycledash/static/lib/bootstrap/scss'));
+
   // BioDalliance
   gulp.src('./node_modules/dalliance/{css,fonts,img,help}/*.*',
            {base: './node_modules/dalliance'})
@@ -109,6 +115,8 @@ gulp.task('staticlibs', function() {
            {base: './node_modules/dalliance/build'})
     .pipe(gulp.dest('./cycledash/static/lib/dalliance'));
 });
+
+
 
 
 // Default task which compiles the JS and then watches the JS and CSS for

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "es5-shim": "^4.0.3",
     "glob": "^4.2.1",
     "gulp": "^3.8.8",
+    "gulp-ext-replace": "^0.2.0",
     "gulp-livereload": "^2.1.1",
     "gulp-peg": "^0.1.2",
     "gulp-react": "^1.0.1",


### PR DESCRIPTION
This commit does 5 things:
1. Changes Bootstrap from css --> sass
2. Uses @import to load Bootstrap and removes its reference from the `layout.html` file.
3. Uses @import to load/cascade the stylesheets, which in turn only requires one stylesheet link per page.
4. Removes `style.css` and `header.css` references from the `layout.html` file
5. Adds `style.css` reference to `comments.html` & `about.html` templates

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/610)

<!-- Reviewable:end -->
