### PR TITLE
sass.on() is not defined in gulp-sass v2.0.1

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -59,7 +59,7 @@ gulp.task('js', function() {
  
 gulp.task('sass', ['staticlibs'], function () {
   return gulp.src('./cycledash/static/scss/*.scss')
-        .pipe(sass().on('error', sass.logError))
+        .pipe(sass.sync().on('error', sass.logError))
         .pipe(gulp.dest('./cycledash/static/css'))
         .pipe(livereload({ auto: false }));
 });


### PR DESCRIPTION
This is what I get when I try to run `gulp sass` with gulp-sass v2.0.1 installed:

```bash
(venv) $ cat node_modules/gulp-sass/package.json |grep version
  "version": "2.0.1",
(venv) $ gulp sass
[15:10:03] Using gulpfile ~/Projects/cycledash/gulpfile.js
[15:10:03] Starting 'staticlibs'...
[15:10:03] Finished 'staticlibs' after 244 ms
[15:10:03] Starting 'sass'...

undefined:0


TypeError: undefined is not a function
```

I was able to track it down to https://github.com/hammerlab/cycledash/blob/master/gulpfile.js#L62 and looks like the `sass().on()` is no more with version 2.0.1. Changing this to `sass.sync().on()` resolves the problem.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/660)
<!-- Reviewable:end -->
