### PR TITLE
Pass the new &format= param to IGV

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -5,7 +5,6 @@
   "sub": true,
   "undef": true,
   "trailing": true,
-  "maxlen": 200,
   "esnext": true,
   "strict": true,
   "lastsemic": false,

--- a/cycledash/static/js/examine/utils.js
+++ b/cycledash/static/js/examine/utils.js
@@ -36,16 +36,17 @@ function makeIGVLink(run, igvHttpfsUrl) {
   }
 
   var nameFilePairs = [
-      ['Run', run.uri],
-      ['Normal', run.normal_bam && run.normal_bam.uri],
-      ['Tumor', run.tumor_bam && run.tumor_bam.uri]
-  ].filter(x => x[1]);
+      ['Run', 'vcf', run.uri],
+      ['Normal', 'bam', run.normal_bam && run.normal_bam.uri],
+      ['Tumor', 'bam', run.tumor_bam && run.tumor_bam.uri]
+  ].filter(x => x[2]);
 
-  var fileParam = nameFilePairs.map(x => fileUrl(x[1])).join(','),
-      nameParam = nameFilePairs.map(x => x[0]).join(',');
+  var fileParam = nameFilePairs.map(x => fileUrl(x[2])).join(','),
+      nameParam = nameFilePairs.map(x => x[0]).join(','),
+      formatParam = nameFilePairs.map(x => x[1]).join(',');
 
   return `http://${LOCAL_IGV_HOST}/load?user=cycledash&genome=hg19` +
-      `&file=${fileParam}&name=${nameParam}`;
+      `&file=${fileParam}&name=${nameParam}&format=${formatParam}`;
 }
 
 /**

--- a/cycledash/static/js/examine/utils.js
+++ b/cycledash/static/js/examine/utils.js
@@ -35,15 +35,15 @@ function makeIGVLink(run, igvHttpfsUrl) {
     return igvHttpfsUrl + file;
   }
 
-  var nameFilePairs = [
-      ['Run', 'vcf', run.uri],
-      ['Normal', 'bam', run.normal_bam && run.normal_bam.uri],
-      ['Tumor', 'bam', run.tumor_bam && run.tumor_bam.uri]
-  ].filter(x => x[2]);
+  var sources = [
+      {name: 'Run',    format: 'vcf', uri: run.uri},
+      {name: 'Normal', format: 'bam', uri: run.normal_bam && run.normal_bam.uri},
+      {name: 'Tumor',  format: 'bam', uri: run.tumor_bam && run.tumor_bam.uri}
+  ].filter(x => x.uri);
 
-  var fileParam = nameFilePairs.map(x => fileUrl(x[2])).join(','),
-      nameParam = nameFilePairs.map(x => x[0]).join(','),
-      formatParam = nameFilePairs.map(x => x[1]).join(',');
+  var fileParam = sources.map(x => fileUrl(x.uri)).join(','),
+      nameParam = sources.map(x => x.name).join(','),
+      formatParam = sources.map(x => x.format).join(',');
 
   return `http://${LOCAL_IGV_HOST}/load?user=cycledash&genome=hg19` +
       `&file=${fileParam}&name=${nameParam}&format=${formatParam}`;

--- a/tests/js/examine-utils-test.js
+++ b/tests/js/examine-utils-test.js
@@ -13,17 +13,17 @@ describe('Examine Utils', function() {
 
     // No BAMs
     var run = { uri };
-    assert.equal('http://localhost:60151/load?user=cycledash&genome=hg19&file=http://example.com/snv.vcf&name=Run',
+    assert.equal('http://localhost:60151/load?user=cycledash&genome=hg19&file=http://example.com/snv.vcf&name=Run&format=vcf',
                  utils.makeIGVLink(run, igvHttpfsUrl));
 
     // One BAM
     run = { uri, normal_bam };
-    assert.equal('http://localhost:60151/load?user=cycledash&genome=hg19&file=http://example.com/snv.vcf,http://example.com/normal.bam&name=Run,Normal',
+    assert.equal('http://localhost:60151/load?user=cycledash&genome=hg19&file=http://example.com/snv.vcf,http://example.com/normal.bam&name=Run,Normal&format=vcf,bam',
                  utils.makeIGVLink(run, igvHttpfsUrl));
 
     // Two BAMs
     run = { uri, normal_bam, tumor_bam };
-    assert.equal('http://localhost:60151/load?user=cycledash&genome=hg19&file=http://example.com/snv.vcf,http://example.com/normal.bam,http://example.com/tumor.bam&name=Run,Normal,Tumor',
+    assert.equal('http://localhost:60151/load?user=cycledash&genome=hg19&file=http://example.com/snv.vcf,http://example.com/normal.bam,http://example.com/tumor.bam&name=Run,Normal,Tumor&format=vcf,bam,bam',
                  utils.makeIGVLink(run, igvHttpfsUrl));
   });
 });


### PR DESCRIPTION
Fixes #574 

I verified that this results in a correctly displayed VCF track for run 270, which has a VCF file ending in `part-r-00000`, rather than `.vcf`.

cc @arahuja

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/702)
<!-- Reviewable:end -->
