### PR TITLE
Update to pileup 0.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jquery": "2.1.1",
     "marked": "^0.3.2",
     "moment": "^2.9.0",
-    "pileup": "^0.1.0",
+    "pileup": "^0.1.1",
     "react": "^0.12.1",
     "store": "^1.3.17",
     "underscore": "^1.7.0"


### PR DESCRIPTION
Fixes #697

I verified that the pileup viewer loads for the third row of run 226 after this update.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/703)
<!-- Reviewable:end -->
