### PR TITLE
Set the initial pileup range correctly

### DIFF
--- a/cycledash/static/js/examine/components/PileupViewer.js
+++ b/cycledash/static/js/examine/components/PileupViewer.js
@@ -132,27 +132,24 @@ var PileupViewer = React.createClass({
     var pileupEl = this.refs.pileupElement.getDOMNode();
 
     this.browser = pileup.create(pileupEl, {
-      range: {
-        contig: '20',  // random position -- it will be changed.
-        start:  2684736 - 50,
-        stop:   2684736 + 50
-      },
+      range: this.rangeForRecord(this.props.selectedRecord),
       tracks: sources
     });
   },
   panToSelection: function() {
-    var rec = this.props.selectedRecord;
-    this.browser.setRange({
-      contig: rec.contig,
-      start: rec.position - 25,
-      stop: rec.position + 25
-    });
+    this.browser.setRange(this.rangeForRecord(this.props.selectedRecord));
   },
   update: function() {
     if (this.props.isOpen && this.props.selectedRecord) {
       this.lazilyCreateDalliance();
-      this.panToSelection();
     }
+  },
+  rangeForRecord: function(record) {
+    return {
+      contig: record.contig,
+      start: record.position - 25,
+      stop: record.position + 25
+    };
   },
   fetchIndexChunks: function() {
     var propBamPathPairs = [['normalBaiChunks', this.props.normalBamPath],

--- a/cycledash/static/js/examine/components/PileupViewer.js
+++ b/cycledash/static/js/examine/components/PileupViewer.js
@@ -144,7 +144,11 @@ var PileupViewer = React.createClass({
   },
   update: function() {
     if (this.props.isOpen && this.props.selectedRecord) {
-      this.lazilyCreateDalliance();
+      if (!this.browser) {
+        this.lazilyCreateDalliance();
+      } else {
+        this.panToSelection();
+      }
     }
   },
   rangeForRecord: function(record) {

--- a/cycledash/static/js/examine/components/PileupViewer.js
+++ b/cycledash/static/js/examine/components/PileupViewer.js
@@ -11,6 +11,9 @@ var React = require('react'),
 var CHUNKS_LOADING = 'loading',
     CHUNKS_NOT_AVAILABLE = null;
 
+// Number of loci to show around the variant.
+var VIEW_WINDOW = 50;
+
 var PileupViewer = React.createClass({
   propTypes: {
     isOpen: React.PropTypes.bool,
@@ -147,8 +150,8 @@ var PileupViewer = React.createClass({
   rangeForRecord: function(record) {
     return {
       contig: record.contig,
-      start: record.position - 25,
-      stop: record.position + 25
+      start: record.position - VIEW_WINDOW / 2,
+      stop: record.position + VIEW_WINDOW / 2
     };
   },
   fetchIndexChunks: function() {


### PR DESCRIPTION
Fixes #722 

In the network view for my test data, I see about half the requests for BAI/BAM data as I did before this change.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/723)
<!-- Reviewable:end -->
