### PR TITLE
Use the newest version of pileup with require support

### DIFF
--- a/cycledash/static/js/examine/components/PileupViewer.js
+++ b/cycledash/static/js/examine/components/PileupViewer.js
@@ -2,10 +2,9 @@
 
 var React = require('react'),
     _ = require('underscore'),
+    pileup = require('pileup'),
     $ = require('jquery'),
     VCFTable = require('./VCFTable');
-// Someday: pileup = require('pileup');
-
 
 // Indicator value that the BAI chunks are still loading.
 var CHUNKS_LOADING = 'loading',

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -29,7 +29,7 @@ var PATHS = {
   ]  // polyfills
 };
 
-var REACT_OPTS = {es6: true},
+var REACT_OPTS = {es6: true, global: true},
     BROWSERIFY_OPTS =  _.extend({entries: PATHS.src, debug: true}, watchify.args);
 
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,8 +30,8 @@ var PATHS = {
 };
 
 var REACT_OPTS = {es6: true, global: true},
-    BROWSERIFY_OPTS =  _.extend({entries: PATHS.src, debug: true}, watchify.args);
-
+    BROWSERIFY_OPTS =  _.extend({entries: PATHS.src, debug: true}, watchify.args),
+    UGLY_OPTS = {global: true};
 
 // Generates compiled JS bundle, automatically recompiling and reloading the
 // browser (by notifying the livereload server, listened to by the js included
@@ -78,8 +78,7 @@ gulp.task('build', function() {
   var srcs = PATHS.polyfills.concat(PATHS.src);
   return browserify(srcs)
     .transform(REACT_OPTS, reactify)
-    .transform({global: true}, uglifyify) // Global: true indicates that uglify
-                                          // will minify all of the module code.
+    .transform(UGLY_OPTS, uglifyify)
     .bundle()
     .pipe(source('bundled.js'))
     .pipe(gulp.dest(PATHS.dest));

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jquery": "2.1.1",
     "marked": "^0.3.2",
     "moment": "^2.9.0",
-    "pileup": "^0.1.1",
+    "pileup": "^0.1.4",
     "react": "^0.12.1",
     "store": "^1.3.17",
     "underscore": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "reactify": "^0.17.1",
     "sinon": "1.13.0",
     "typeahead.js": "^0.10.5",
-    "uglifyify": "^2.5.0",
+    "uglifyify": "^3.0.1",
     "vcf.js": "^0.2.6",
     "vinyl-source-stream": "^1.0.0",
     "watchify": "^1.0.2"


### PR DESCRIPTION
- upgrade [pileup.js](https://github.com/hammerlab/pileup.js) to `v0.1.4` and access the module with `require('pileup')` instead of depending on global variables
- when bundling the source, _reactify_ globally so that dependencies also get transformed (the new [pileup.js](https://github.com/hammerlab/pileup.js) needs this until we resolve this issue: https://github.com/hammerlab/pileup.js/issues/188)
- upgrade the [uglifyify](https://www.npmjs.com/package/uglifyify) as the older version was not able to minify React properly causing conflicts across pileup.js and Cycledash instances

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/726)

<!-- Reviewable:end -->
