### PR TITLE
Remove obsolete dependencies (wsgiref and dpxdt) from the requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,8 +21,6 @@ pytz==2014.4
 pywebhdfs==0.2.3
 requests==2.3.0
 voluptuous==0.8.7
-wsgiref==0.1.2
-dpxdt==0.1.5
 psycopg2==2.5.4
 pylint==1.4.1
 humanize==0.5.1


### PR DESCRIPTION
These libraries do not support Python 3.4.x and are not being used any more.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/748)
<!-- Reviewable:end -->
