### PR TITLE
Bump to pileup 0.2

### DIFF
--- a/cycledash/static/scss/examine.scss
+++ b/cycledash/static/scss/examine.scss
@@ -392,6 +392,8 @@ a, a:hover {
   flex: 1;
   height: auto;  /* overrides defaults from pileup.css */
   overflow-y: auto;  /* extra content scrolls */
+  /* a vertical scroll bar can result in a horizontal bar, which we don't want. */
+  overflow-x: hidden;
 }
 .pileup {
   border-top: 1px solid $color-gray-medium;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "jquery": "2.1.1",
     "marked": "^0.3.2",
     "moment": "^2.9.0",
-    "pileup": "^0.1.4",
+    "pileup": "^0.2.0",
     "react": "^0.12.2",
     "store": "^1.3.17",
     "underscore": "^1.7.0"


### PR DESCRIPTION
This gets us Arman's improvements to the way JS files are distributed, plus the loading indicator and track labels.

I made one CSS tweak to kill an unwanted horizontal scroll bar.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/775)

<!-- Reviewable:end -->
