### PR TITLE
Remind users to source ENV.sh before using init_db during setup

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -43,6 +43,7 @@ You will need to generate an `ENV.sh` file using 'make initenv'. `ENV.sh` contai
 ```
 make initenv                       # Initialize environment file.
 $EDITOR ENV.sh                     # Fill in values.
+source ENV.sh                      # make sure all our environment variables are around
 ```
 
 


### PR DESCRIPTION
Although `run.sh` implicitly [sources `ENV.sh`](https://github.com/hammerlab/cycledash/blob/master/run.sh#L5); after creating the `ENV.sh` file during the initial setup, users need to source it before calling `init_db.py` script. Otherwise, the `init_db.py` complains about the missing DB variable:

```bash
# initial setup
(venv)arman@narnia cycledash > make initenv
Creating ENV template...
ENV.sh created, edit it to configure CycleDash.

# this fails
(venv)arman@narnia cycledash > python scripts/init_db.py
No $DATABASE_URI found; make sure to source your environment file!

# and this succeeds
(venv)arman@narnia cycledash > source ENV.sh 
(venv)arman@narnia cycledash > python scripts/init_db.py
Are you sure you want to initialize the Cycledash database in postgres:///cycledash? (y/n): y
INFO  [alembic.migration] Context impl PostgresqlImpl.
INFO  [alembic.migration] Will assume transactional DDL.
Created Cycledash DB and stamped with most recent migration!
...
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/812)
<!-- Reviewable:end -->
