### PR TITLE
Add required but previously missing fields to the package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,15 @@
 {
   "name": "cycledash",
   "description": "Variant Caller Analysis Dashboard and Data Management System",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/hammerlab/cycledash.git"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/hammerlab/cycledash/issues"
+  },
+  "homepage": "https://github.com/hammerlab/cycledash",
   "dependencies": {
     "bootstrap": "^3.2.0",
     "d3": "^3.4.11",


### PR DESCRIPTION
Without these annotations, NPM was complaining every time we try to install via `package.json`:

```bash
$ npm install
npm WARN package.json cycledash@ No repository field.
npm WARN package.json cycledash@ No license field.
```

New annotations address this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/815)
<!-- Reviewable:end -->
