### PR TITLE
Rename and move Bootstrap files in a single step

### DIFF
--- a/cycledash/static/scss/style.scss
+++ b/cycledash/static/scss/style.scss
@@ -1,4 +1,4 @@
-@import '../lib/bootstrap/scss/bootstrap';
+@import '../lib/bootstrap/css/bootstrap.min';
 @import 'variables';
 @import 'header';
 

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -98,28 +98,24 @@ gulp.task('staticlibs', function() {
              {base: './node_modules/jquery/dist'})
       .pipe(gulp.dest('./cycledash/static/lib/jquery')),
 
-    // Bootstrap
-    gulp.src('./node_modules/bootstrap/dist/**/*',
-             {base: './node_modules/bootstrap/dist'})
-      .pipe(gulp.dest('./cycledash/static/lib/bootstrap')),
+      // Bootstrap
+      gulp.src('./node_modules/bootstrap/dist/**/*',
+               {base: './node_modules/bootstrap/dist'})
+        .pipe(ext_replace('.scss', '.css'))
+        .pipe(gulp.dest('./cycledash/static/lib/bootstrap/')),
 
-    // Change bootstrap.min.css to bootstrap.min.scss
-    gulp.src('./cycledash/static/lib/bootstrap/css/bootstrap.min.css')
-      .pipe(ext_replace('.scss', '.min.css'))
-      .pipe(gulp.dest('./cycledash/static/lib/bootstrap/scss')),
+      // Move glyphicons to static/fonts
+      gulp.src('./cycledash/static/lib/bootstrap/fonts/*',
+              {base: './cycledash/static/lib/bootstrap/fonts/'})
+        .pipe(gulp.dest('./cycledash/static/fonts')),
 
-    // Move glyphicons to static/fonts
-    gulp.src('./cycledash/static/lib/bootstrap/fonts/*',
-            {base: './cycledash/static/lib/bootstrap/fonts/'})
-      .pipe(gulp.dest('./cycledash/static/fonts')),
-
-    // pileup.js
-    gulp.src('./node_modules/pileup/style/*.*',
-             {base: './node_modules/pileup/style'})
-       .pipe(gulp.dest('./cycledash/static/lib/pileup.js')),
-    gulp.src('./node_modules/pileup/build/*.js',
-             {base: './node_modules/pileup/build'})
-      .pipe(gulp.dest('./cycledash/static/lib/pileup.js'))
+      // pileup.js
+      gulp.src('./node_modules/pileup/style/*.*',
+               {base: './node_modules/pileup/style'})
+         .pipe(gulp.dest('./cycledash/static/lib/pileup.js')),
+      gulp.src('./node_modules/pileup/build/*.js',
+               {base: './node_modules/pileup/build'})
+        .pipe(gulp.dest('./cycledash/static/lib/pileup.js'))
   ]);
 });
 


### PR DESCRIPTION
Previously the merged gulp tasks that suppose to prepare the Bootstrap files for importing within `style.scss` were failing to do so because one was depending on the other but they were being run synchronously. This was why we weren't seeing the error on the second run:

```bash
(venv)arman@narnia cycledash > rm -f cycledash/static/css/* && rm -f cycledash/static/fonts/* && rm -rf cycledash/static/lib/*

# First run fails to create bootstrap scss due to race condition
(venv)arman@narnia cycledash > gulp staticlibs
[15:10:46] Using gulpfile ~/Projects/cycledash/gulpfile.js
[15:10:46] Starting 'staticlibs'...
[15:10:47] Finished 'staticlibs' after 94 ms
(venv)arman@narnia cycledash > ls cycledash/static/lib/bootstrap/scss
ls: cycledash/static/lib/bootstrap/scss: No such file or directory

# Second run is OK
(venv)arman@narnia cycledash > gulp staticlibs
[15:11:25] Using gulpfile ~/Projects/cycledash/gulpfile.js
[15:11:25] Starting 'staticlibs'...
[15:11:25] Finished 'staticlibs' after 73 ms
(venv)arman@narnia cycledash > ls cycledash/static/lib/bootstrap/scss
bootstrap.scss
```

This collapses the two-step Bootstrap procedure into a single-step one, hence fixes #782.