### PR TITLE
Fix VCF download feature

### DIFF
--- a/cycledash/auth.py
+++ b/cycledash/auth.py
@@ -3,6 +3,7 @@ from flask import request, redirect, render_template
 from flask.ext.login import login_user, logout_user
 from sqlalchemy import exc
 import voluptuous
+import base64
 
 from cycledash import db, bcrypt, login_manager
 from cycledash.helpers import prepare_request_data, safely_redirect_to_next
@@ -107,3 +108,33 @@ def register():
             login_user(user)
             return redirect('/')
     return render_template('register.html', errors=errors)
+
+def check_login_from_key(api_key):
+    username, password = api_key.split(":")
+    return check_login(username, password)
+
+def load_user_from_request(request):
+    """Support for basic authorization."""
+    # first, try to login using the api_key url arg
+    api_key = request.args.get('api_key')
+    if api_key:
+        user = check_login_from_key(api_key)
+        if user:
+            return user
+
+    # next, try to login using Basic Auth
+    api_key = request.headers.get('Authorization')
+    if api_key:
+        api_key = api_key.replace('Basic ', '', 1)
+        try:
+            api_key = base64.b64decode(api_key)
+        except TypeError:
+            pass
+        user = check_login_from_key(api_key)
+        if user:
+            return user
+
+    # finally, return None if both methods did not login the user
+    return None
+
+login_manager.request_loader(load_user_from_request)

--- a/cycledash/auth.py
+++ b/cycledash/auth.py
@@ -115,13 +115,6 @@ def check_login_from_key(api_key):
 
 def load_user_from_request(request):
     """Support for basic authorization."""
-    # first, try to login using the api_key url arg
-    api_key = request.args.get('api_key')
-    if api_key:
-        user = check_login_from_key(api_key)
-        if user:
-            return user
-
     # next, try to login using Basic Auth
     api_key = request.headers.get('Authorization')
     if api_key:

--- a/cycledash/views.py
+++ b/cycledash/views.py
@@ -161,7 +161,7 @@ def download_vcf(run_id):
     query = json.loads(request.args.get('query'))
     genotypes = cycledash.api.genotypes.genotypes_for_records(run_id, query)
     fd = tempfile.NamedTemporaryFile(mode='w+b')
-    with tables(db, 'vcfs') as (con, vcfs):
+    with tables(db.engine, 'vcfs') as (con, vcfs):
         q = select(
             [vcfs.c.extant_columns, vcfs.c.vcf_header]
         ).where(vcfs.c.id == run_id)

--- a/tests/python/test_download.py
+++ b/tests/python/test_download.py
@@ -1,6 +1,7 @@
 import mock
 import nose
 import json
+import urllib
 
 from cycledash import app, db
 from common.helpers import tables
@@ -33,14 +34,13 @@ class TestDownload(helpers.ResourceTest):
 
     def test_download(self):
         # match the URL with the default download button href
-        downUrl = ("/runs/" + str(self.run['id']) + "/download?query="
-                   "%7B%22range%22%3A%7B%22start%22%3Anull%2C%22end%22%3Anull"
-                   "%2C%22contig%22%3Anull%7D%2C%22filters%22%3A%5B%5D%2C%22"
-                   "sortBy%22%3A%5B%7B%22order%22%3A%22asc%22%2C%22"
-                   "columnName%22%3A%22contig%22%7D%2C%7B%22order"
-                   "%22%3A%22asc%22%2C%22columnName%22%3A%22position"
-                   "%22%7D%5D%2C%22page%22%3A0%2C%22limit%22%3A250%2C%22"
-                   "compareToVcfId%22%3Anull%7D")
+        queryStr = ('{"range":{"start":null,"end":null,"contig":null},'
+                    '"filters":[],'
+                    '"sortBy":[{"columnName":"contig","order":"asc"},'
+                    '{"columnName":"position","order":"asc"}],'
+                    '"page":0,"limit":250,"compareToVcfId":null}')
+        downUrl = ("/runs/" + str(self.run['id']) + "/download?query=" +
+                   urllib.quote(queryStr))
         r = self.get(downUrl)
         assert r.status_code == 200  # no fail
         assert len(r.data) == 1193  # might differ from the original file

--- a/tests/python/test_download.py
+++ b/tests/python/test_download.py
@@ -1,0 +1,46 @@
+import mock
+import nose
+import json
+
+from cycledash import app, db
+from common.helpers import tables
+
+from test_projects_api import create_project_with_name
+from test_bams_api import create_bam_with_name
+from test_runs_api import create_run_with_uri
+from workers.genotype_extractor import _extract
+
+import helpers
+
+class TestDownload(helpers.ResourceTest):
+    """ Creates a project from a test file, extracts the genotype
+        and tries to download it back. """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.project = create_project_with_name('Downloadable project')
+        cls.run = create_run_with_uri(cls.project['id'],
+                                       '/tests/data/somatic_hg19_14muts.vcf')
+        _extract(cls.run['id'])
+        return super(TestDownload, cls).setUpClass()
+
+    def tearDown(self):
+        with tables(db.engine, 'projects', 'vcfs', 'genotypes') \
+                as (con, projects, runs, genotypes):
+            genotypes.delete().execute()
+            runs.delete().execute()
+            projects.delete().execute()
+
+    def test_download(self):
+        # match the URL with the default download button href
+        downUrl = ("/runs/" + str(self.run['id']) + "/download?query="
+                   "%7B%22range%22%3A%7B%22start%22%3Anull%2C%22end%22%3Anull"
+                   "%2C%22contig%22%3Anull%7D%2C%22filters%22%3A%5B%5D%2C%22"
+                   "sortBy%22%3A%5B%7B%22order%22%3A%22asc%22%2C%22"
+                   "columnName%22%3A%22contig%22%7D%2C%7B%22order"
+                   "%22%3A%22asc%22%2C%22columnName%22%3A%22position"
+                   "%22%7D%5D%2C%22page%22%3A0%2C%22limit%22%3A250%2C%22"
+                   "compareToVcfId%22%3Anull%7D")
+        r = self.get(downUrl)
+        assert r.status_code == 200  # no fail
+        assert len(r.data) == 1193  # might differ from the original file


### PR DESCRIPTION
See #738 for more context.

When clicked on the download, we were getting this error logged:

```
----------------------------------------
Exception happened during processing of request from ('127.0.0.1', 59979)
Traceback (most recent call last):
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 295, in _handle_request_noblock
    self.process_request(request, client_address)
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 321, in process_request
    self.finish_request(request, client_address)
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 334, in finish_request
    self.RequestHandlerClass(request, client_address, self)
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 657, in __init__
    self.finish()
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/SocketServer.py", line 716, in finish
    self.wfile.close()
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 283, in close
    self.flush()
  File "/usr/local/Cellar/python/2.7.10/Frameworks/Python.framework/Versions/2.7/lib/python2.7/socket.py", line 307, in flush
    self._sock.sendall(view[write_offset:write_offset+buffer_size])
error: [Errno 32] Broken pipe
----------------------------------------
```

which was stemming from a simple coding mistake.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/818)
<!-- Reviewable:end -->
