### PR TITLE
Suggest using UTC timezone for better compatibility with timestamps

### DIFF
--- a/DEVELOP.md
+++ b/DEVELOP.md
@@ -48,7 +48,11 @@ $EDITOR ENV.sh                     # Fill in values.
 
 ### 4. Set up the Database (Postgres)
 
-We use PostgreSQL as our datastore, with the schema described in `schema.sql`.
+We use PostgreSQL as our datastore, with the schema described in `schema.sql` and `UTC` timezone:
+
+```bash
+$EDITOR /usr/local/var/postgres/postgresql.conf  # timezone = 'UTC'
+```
 
 On OS X, setting up and running psql might look like this:
 


### PR DESCRIPTION
I recently wiped my develop environment on Mac OS X 10.10 and with that came a new PostgreSQL installation. Everything was working fine but the `seltests` were failing due to different timestamps on the examine pages for various test runs. 

I was able to resolve this issue by switching my default timezone within `postgresql.conf` and thought that this was something specific to my setup; but, looks like issue #727 is also related to this and mentioning this within our `DEVELOP.md` helps clarifying this issue.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/819)
<!-- Reviewable:end -->
