### PR TITLE
Make true pos count agree with true pos checks

### DIFF
--- a/cycledash/api/genotypes.py
+++ b/cycledash/api/genotypes.py
@@ -109,7 +109,8 @@ def get(run_id, query, with_stats=True):
                 g.c.contig == gt.c.contig,
                 g.c.position == gt.c.position,
                 g.c.reference == gt.c.reference,
-                g.c.alternates == gt.c.alternates))
+                g.c.alternates == gt.c.alternates,
+                g.c.sample_name == gt.c.sample_name))
             valid_column = label('tag:true-positive', gt.c.contig != None)
             q = (select(g.c + [valid_column])
                  .select_from(joined_q)


### PR DESCRIPTION
This means we don't use the sample name to test concordance, possibly
leading to weird numbers when looking at multi-sample VCFs.

fixes #822

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/825)

<!-- Reviewable:end -->
