### PR TITLE
Sanity-check and debug pdifftests 

### DIFF
--- a/scripts/update-screenshots.sh
+++ b/scripts/update-screenshots.sh
@@ -82,17 +82,9 @@ else
     echo "SauceConnect tunnel detected already running, will attempt to use that."
 fi
 
-capabilities=$(python <<EOF
-import json
-capabilities = json.loads(open('$SELTEST_CAPABILITIES').read())
-capabilities['tunnel-identifier'] = '$TRAVIS_JOB_NUMBER'
-print(json.dumps(capabilities))
-EOF
-)
-
 # Run the actual tests now that we're ready.
 sel update -b remote \
-    --remote-capabilities="$capabilities" \
+    --remote-capabilities="$(cat $SELTEST_CAPABILITIES)" \
     --remote-command-executor="http://$SAUCE_USERNAME:$SAUCE_ACCESS_KEY@$SAUCE_URL" \
     -o $BASE/images \
     "$@" \


### PR DESCRIPTION
This reverts the changes introduced as part of #814 into the `update-screenshots.sh`. Note that there are no changes to the screenshots and this passes the pdfifftests without any problem.

However, if you are to check this code out and run `scripts/update-screenshots.sh`, you do get different screenshots:

```bash
$ git branch |grep "*"
* sanity-check-pdiffs

$ git status
On branch sanity-check-pdiffs
Your branch is up-to-date with 'origin/sanity-check-pdiffs'.
nothing to commit, working directory clean

$ bash scripts/update-screenshots.sh 
Creating test DB, logging to tests/pdifftests/logs/DB_LOGs.txt...done.
Starting test server, logging to tests/pdifftests/logs/TEST_SERVER_LOGS.txt...done.
Opening SauceConnect tunnel from localhost..........................done.
Updating images...
 for Examine
  ✗ examine_bad-query: screenshots differ, updating
  ✗ examine_base: screenshots differ, updating
 ...
```

which is unexpected as these new screenshots don't match with the ones generated via Travis.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/826)
<!-- Reviewable:end -->
