### PR TITLE
Embed the GA4GH API in Cycledash

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ sudo: false
 language: python
 python:
 - '2.7'
+before_install:
+  - pip install --upgrade pip  # update to pip 7.x
 install: "./scripts/travis-setup.sh"
 script: "./scripts/travis-test.sh"
 addons:

--- a/ENVTEMPLATE.sh
+++ b/ENVTEMPLATE.sh
@@ -12,10 +12,12 @@ export SECRET_KEY  # Set to something real + random for deployment
 # True for automatic reloading & debugging JS insertion.
 export USE_RELOADER=False
 
-
 ###  Optional:
 ## This is one way to get fancy fonts working in CycleDash.
 # export TYPEKIT_URL="//use.typekit.net/SOMETHING.js"
+
+# To serve BAM files using the GA4GH API
+# export GA4GH_ROOT=/hdfs
 
 ## Useful to specify where CSV files will be written to when importing data into
 ## Postgres via CSV, which is how workers/genotype_extractor.py works.

--- a/config.py
+++ b/config.py
@@ -38,6 +38,8 @@ BCRYPT_LOG_ROUNDS = int(os.environ.get('BCRYPT_LOG_ROUNDS', 10))
 # cf. http://flask-login.readthedocs.org/en/latest/ "Protecting views"
 LOGIN_DISABLED = handle_false(os.environ.get('LOGIN_DISABLED', False))
 
+GA4GH_ROOT = os.environ.get('GA4GH_ROOT')
+
 
 del os
 del subprocess

--- a/cycledash/api/__init__.py
+++ b/cycledash/api/__init__.py
@@ -102,4 +102,4 @@ def validate_with(schema):
     return decorator
 
 
-import projects, bams, runs, genotypes, tasks, comments
+import projects, bams, runs, genotypes, tasks, comments, ga4gh_wrapper

--- a/cycledash/api/ga4gh_wrapper.py
+++ b/cycledash/api/ga4gh_wrapper.py
@@ -2,6 +2,11 @@
 
 import os.path
 
+from common.helpers import tables
+from cycledash.helpers import abort_if_none_for
+from cycledash import db
+from sqlalchemy import select
+
 import ga4gh.backend as backend
 import ga4gh.datamodel.datasets as datasets
 import ga4gh.datamodel.reads as reads
@@ -11,13 +16,13 @@ class DirectBamBackend(backend.AbstractBackend):
     """Barebones GA4GH backend which supports the /reads/search API."""
 
     def __init__(self, root_path):
-        self._rootPath = root_path
+        self._root_path = root_path
         super(DirectBamBackend, self).__init__()
 
     def readsGenerator(self, request):
         """Returns an iterator of reads which match the request criteria.
 
-        The "readGroupIds" field of the request should be a path to a BAM file.
+        The "readGroupIds" field of the request should be the ID of a BAM.
 
         The data hierarchy in the GA4GH server is
 
@@ -29,17 +34,22 @@ class DirectBamBackend(backend.AbstractBackend):
         create a fake dataset and a fake read group set to contain the read
         group.
         """
-        relative_path = request.readGroupIds[0]
-        absolute_path = os.path.join(self._rootPath, relative_path)
+        bam_id = int(request.readGroupIds[0])
+        bam = None
+        with tables(db.engine, 'bams') as (con, bams):
+            q = select(bams.c).where(bams.c.id == bam_id)
+            bam = dict(abort_if_none_for('bam')(q.execute().fetchone(), bam_id))
+
+        bam_path = self._root_path + bam['uri']
 
         # The strings are meaningless dummy values. They could be anything.
         dataset = datasets.AbstractDataset('dataset1')
-        localId = 'readGroupSetId'
-        
-        read_group_set = reads.AbstractReadGroupSet(dataset, localId)
+        local_id = 'readGroupSetId'
+
+        read_group_set = reads.AbstractReadGroupSet(dataset, local_id)
 
         # TODO: cache read_group? It might be re-reading the index on every request.
-        read_group = reads.HtslibReadGroup(read_group_set, localId, absolute_path)
+        read_group = reads.HtslibReadGroup(read_group_set, local_id, bam_path)
 
         read_group_set.addReadGroup(read_group)
         dataset.addReadGroupSet(read_group_set)

--- a/cycledash/api/ga4gh_wrapper.py
+++ b/cycledash/api/ga4gh_wrapper.py
@@ -1,0 +1,47 @@
+"""A subset of the GA4GH API for use in Cycledash."""
+
+import os.path
+
+import ga4gh.backend as backend
+import ga4gh.datamodel.datasets as datasets
+import ga4gh.datamodel.reads as reads
+
+
+class DirectBamBackend(backend.AbstractBackend):
+    """Barebones GA4GH backend which supports the /reads/search API."""
+
+    def __init__(self, root_path):
+        self._rootPath = root_path
+        super(DirectBamBackend, self).__init__()
+
+    def readsGenerator(self, request):
+        """Returns an iterator of reads which match the request criteria.
+
+        The "readGroupIds" field of the request should be a path to a BAM file.
+
+        The data hierarchy in the GA4GH server is
+
+            dataset -> read group set -> read group
+
+        A "read group" is equivalent to a BAM file. In Cycledash, we just want
+        to serve BAM files, so the first two layers of the hierarchy are
+        irrelevant. The GA4GH server requires them, though, so we have to
+        create a fake dataset and a fake read group set to contain the read
+        group.
+        """
+        relative_path = request.readGroupIds[0]
+        absolute_path = os.path.join(self._rootPath, relative_path)
+
+        # The strings are meaningless dummy values. They could be anything.
+        dataset = datasets.AbstractDataset('dataset1')
+        localId = 'readGroupSetId'
+        
+        read_group_set = reads.AbstractReadGroupSet(dataset, localId)
+
+        # TODO: cache read_group? It might be re-reading the index on every request.
+        read_group = reads.HtslibReadGroup(read_group_set, localId, absolute_path)
+
+        read_group_set.addReadGroup(read_group)
+        dataset.addReadGroupSet(read_group_set)
+
+        return backend.ReadsIntervalIterator(request, read_group)

--- a/cycledash/views.py
+++ b/cycledash/views.py
@@ -63,13 +63,13 @@ api.add_resource(cycledash.api.genotypes.Genotypes,
 #############################
 # (subset of the) GA4GH API #
 #############################
-ga4gh_backend = cycledash.api.ga4gh_wrapper.DirectBamBackend(app.config['GA4GH_ROOT'])
+ga4gh_backend = cycledash.api.ga4gh_wrapper.DirectBamBackend(app.config.get('GA4GH_ROOT', ''))
 
 @app.route('/ga4gh/reads/search', methods=['POST'])
 def searchReads():
     endpoint = ga4gh_backend.runSearchReads
-    responseStr = endpoint(request.get_data())
-    return Response(responseStr, status=200, mimetype='application/json')
+    response_string = endpoint(request.get_data())
+    return Response(response_string, status=200, mimetype='application/json')
 
 
 ##############

--- a/cycledash/views.py
+++ b/cycledash/views.py
@@ -2,7 +2,7 @@
 """Defines all views for CycleDash."""
 import json
 import tempfile
-from flask import request, redirect, render_template, send_file
+from flask import request, redirect, render_template, send_file, Response
 from flask.ext.login import login_required
 from sqlalchemy import select, desc, exc
 import voluptuous
@@ -58,6 +58,18 @@ api.add_resource(cycledash.api.comments.CommentsForVcf,
 api.add_resource(cycledash.api.genotypes.Genotypes,
                  '/runs/<int:run_id>/genotypes',
                  endpoint='api:genotypes')
+
+
+#############################
+# (subset of the) GA4GH API #
+#############################
+ga4gh_backend = cycledash.api.ga4gh_wrapper.DirectBamBackend(app.config['GA4GH_ROOT'])
+
+@app.route('/ga4gh/reads/search', methods=['POST'])
+def searchReads():
+    endpoint = ga4gh_backend.runSearchReads
+    responseStr = endpoint(request.get_data())
+    return Response(responseStr, status=200, mimetype='application/json')
 
 
 ##############

--- a/requirements.txt
+++ b/requirements.txt
@@ -32,3 +32,4 @@ seltest==0.2.8
 flask-login==0.2.11
 flask-bcrypt==0.6.2
 alembic==0.7.7
+-e 'git+https://github.com/ga4gh/server.git@49e3acf7947#egg=ga4gh'


### PR DESCRIPTION
Fixes #744 

This add a `/ga4gh/reads/search` API endpoint to Cycledash which could be used to greatly speed up BAM loading.

Things to like about this:
- It works!
- It doesn't require running ga4gh as a separate server
- It doesn't require us to modify ga4gh in [controversial ways](https://github.com/ga4gh/server/pull/485)
- It reuses all of the data serialization/pagination logic from the ga4gh reference server

Things to not like:
- We're not depending on anything released on PyPI. It's unclear to me if the server was ever intended to be used in this way.
- ga4gh pulls in PySAM as a dependency, which will slow down Travis & complicate deployment.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/833)

<!-- Reviewable:end -->
