### PR TITLE
Disable screenshot-based pdiff tests on Travis

### DIFF
--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -12,9 +12,6 @@ echo 'Running tests in reverse...'
 echo 'Linting...'
 ./scripts/lint.sh
 
-echo 'Running seltests...'
-./scripts/travis-run-pdiff-tests.sh
-
 if [ $CI ]; then
   set +o errexit
   ./scripts/travis-coverage.sh


### PR DESCRIPTION
We have been getting inconsistent screenshots from Sauce Labs across different runs/tests, which is causing us trouble with new feature branches. This will disable the part of tests run on Travis that compares the screenshots.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/837)
<!-- Reviewable:end -->
