### PR TITLE
Make genotype_extractor work even if varcode fails

### DIFF
--- a/workers/shared.py
+++ b/workers/shared.py
@@ -92,6 +92,8 @@ def guess_ensembl_release(filepath):
         release = varcode.load_vcf(filepath)[0].ensembl.release
     except ValueError:  # no guesses from varcode, return default
         release = config.ENSEMBL_RELEASE
+    except Exception:  # varcode cannot handle this one, so go w/ default
+        release = config.ENSEMBL_RELEASE
     finally:
         return release
 


### PR DESCRIPTION
Since #816, we were using varcode to infer the release of the VCF file; but when varcode fails #840 due to unexpected error, genotype extractor should still work and use the default release.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/841)
<!-- Reviewable:end -->
