### PR TITLE
Bump pileup version to 0.4.0

### DIFF
--- a/cycledash/static/scss/examine.scss
+++ b/cycledash/static/scss/examine.scss
@@ -585,5 +585,5 @@ a.download-vcf {
   border-top: 1px solid $color-gray-medium;
 }
 /* removes unwanted white space after SVG (issue #805) */
-#pileup-container .track-content svg {
+#pileup-container .track-content canvas {
   display: block; }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "jquery": "2.1.1",
     "marked": "^0.3.2",
     "moment": "^2.9.0",
-    "pileup": "^0.3.0",
+    "pileup": "^0.4.0",
     "react": "^0.12.2",
     "underscore": "^1.7.0"
   },


### PR DESCRIPTION
Highlights of this update include:
- Paired reads (See #99)
- Faster canvas-based rendering

![pileup 4 in cycledash](https://cloud.githubusercontent.com/assets/98301/10207850/15796502-679d-11e5-817a-b5ef76587a83.png)

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/849)

<!-- Reviewable:end -->
