### PR TITLE
Adds a min-height to table container

### DIFF
--- a/cycledash/static/scss/examine.scss
+++ b/cycledash/static/scss/examine.scss
@@ -235,6 +235,7 @@ a.download-vcf {
 /*------[ VCF Table ]------*/
 .examine-table-container {
   overflow: auto;
+  min-height: 50vh;
 }
 .vcf-table {
   @extend .table, .table-striped;


### PR DESCRIPTION
This is to fix the tooltip bug seen in #828. I'm setting a `min-height` on the table container in order to show the overflowing tooltips. You'll notice that the min-height unit is in `vh`, which refers to "viewport height". This keeps the height flexible and relative to the height of the viewport, rather than using an arbitrary static `px` value. It's pretty awesome and widely [supported](http://caniuse.com/#feat=viewport-units). You can read more about it [here](http://stanhub.com/how-to-make-div-element-100-height-of-browser-window-using-css-only/).

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/850)

<!-- Reviewable:end -->
