### PR TITLE
Update to React 0.14

### DIFF
--- a/cycledash/static/js/comments/comments.js
+++ b/cycledash/static/js/comments/comments.js
@@ -1,8 +1,9 @@
 'use strict';
 var React = require('react'),
+    ReactDOM = require('react-dom'),
     CommentsPage = require('./components/comment').CommentsPage;
 
 
 window.renderCommentsPage = function(el, comments) {
-  React.render(<CommentsPage comments={comments} />, el);
+  ReactDOM.render(<CommentsPage comments={comments} />, el);
 };

--- a/cycledash/static/js/examine/components/CommentBox.js
+++ b/cycledash/static/js/examine/components/CommentBox.js
@@ -9,7 +9,7 @@
 
 var _ = require('underscore'),
     utils = require('../utils'),
-    React = require('react/addons'),
+    React = require('react'),
     marked = require('marked'),
     moment = require('moment');
 

--- a/cycledash/static/js/examine/components/ExamineInformation.js
+++ b/cycledash/static/js/examine/components/ExamineInformation.js
@@ -1,6 +1,6 @@
 "use strict";
 
-var React = require('react/addons');
+var React = require('react');
 
 
 var ExamineInformation = React.createClass({

--- a/cycledash/static/js/examine/components/ExaminePage.js
+++ b/cycledash/static/js/examine/components/ExaminePage.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var React = require('react'),
-    // PileupViewer = require('./PileupViewer'),
+    PileupViewer = require('./PileupViewer'),
     StatsSummary = require('./StatsSummary'),
     RecordsShown = require('./RecordsShown'),
     VCFTable = require('./VCFTable'),
@@ -84,20 +84,19 @@ var ExaminePage = React.createClass({
 
     // The pileup viewer still needs to be created, even if it's not visible,
     // so that it will pre-fetch the index chunks.
-    var pileupViewer = null;
-    // (
-    //   <PileupViewer key="pileup-viewer"
-    //                 vcfPath={run.uri}
-    //                 normalBamPath={run.normal_bam && run.normal_bam.uri}
-    //                 tumorBamPath={run.tumor_bam && run.tumor_bam.uri}
-    //                 igvHttpfsUrl={props.igvHttpfsUrl}
-    //                 selectedRecord={state.selectedRecord}
-    //                 columns={state.columns}
-    //                 isOpen={state.isViewerOpen}
-    //                 handlePreviousRecord={this.handlePreviousRecord}
-    //                 handleNextRecord={this.handleNextRecord}
-    //                 handleClose={this.handleCloseViewer} />
-    // );
+    var pileupViewer = (
+      <PileupViewer key="pileup-viewer"
+                    vcfPath={run.uri}
+                    normalBamPath={run.normal_bam && run.normal_bam.uri}
+                    tumorBamPath={run.tumor_bam && run.tumor_bam.uri}
+                    igvHttpfsUrl={props.igvHttpfsUrl}
+                    selectedRecord={state.selectedRecord}
+                    columns={state.columns}
+                    isOpen={state.isViewerOpen}
+                    handlePreviousRecord={this.handlePreviousRecord}
+                    handleNextRecord={this.handleNextRecord}
+                    handleClose={this.handleCloseViewer} />
+    );
 
     if (state.isViewerOpen) {
       return (

--- a/cycledash/static/js/examine/components/ExaminePage.js
+++ b/cycledash/static/js/examine/components/ExaminePage.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var React = require('react'),
-    PileupViewer = require('./PileupViewer'),
+    // PileupViewer = require('./PileupViewer'),
     StatsSummary = require('./StatsSummary'),
     RecordsShown = require('./RecordsShown'),
     VCFTable = require('./VCFTable'),
@@ -84,19 +84,20 @@ var ExaminePage = React.createClass({
 
     // The pileup viewer still needs to be created, even if it's not visible,
     // so that it will pre-fetch the index chunks.
-    var pileupViewer = (
-      <PileupViewer key="pileup-viewer"
-                    vcfPath={run.uri}
-                    normalBamPath={run.normal_bam && run.normal_bam.uri}
-                    tumorBamPath={run.tumor_bam && run.tumor_bam.uri}
-                    igvHttpfsUrl={props.igvHttpfsUrl}
-                    selectedRecord={state.selectedRecord}
-                    columns={state.columns}
-                    isOpen={state.isViewerOpen}
-                    handlePreviousRecord={this.handlePreviousRecord}
-                    handleNextRecord={this.handleNextRecord}
-                    handleClose={this.handleCloseViewer} />
-    );
+    var pileupViewer = null;
+    // (
+    //   <PileupViewer key="pileup-viewer"
+    //                 vcfPath={run.uri}
+    //                 normalBamPath={run.normal_bam && run.normal_bam.uri}
+    //                 tumorBamPath={run.tumor_bam && run.tumor_bam.uri}
+    //                 igvHttpfsUrl={props.igvHttpfsUrl}
+    //                 selectedRecord={state.selectedRecord}
+    //                 columns={state.columns}
+    //                 isOpen={state.isViewerOpen}
+    //                 handlePreviousRecord={this.handlePreviousRecord}
+    //                 handleNextRecord={this.handleNextRecord}
+    //                 handleClose={this.handleCloseViewer} />
+    // );
 
     if (state.isViewerOpen) {
       return (

--- a/cycledash/static/js/examine/components/PileupViewer.js
+++ b/cycledash/static/js/examine/components/PileupViewer.js
@@ -144,7 +144,7 @@ var PileupViewer = React.createClass({
       sources = sources.concat(bamSource('Tumor', 'tumor', this.props.tumorBamPath, this.state.tumorBaiChunks));
     }
 
-    var pileupEl = this.refs.pileupElement.getDOMNode();
+    var pileupEl = this.refs.pileupElement;
 
     this.browser = pileup.create(pileupEl, {
       range: this.rangeForRecord(this.props.selectedRecord),

--- a/cycledash/static/js/examine/components/QueryBox.js
+++ b/cycledash/static/js/examine/components/QueryBox.js
@@ -5,6 +5,7 @@
 'use strict';
 
 var React = require('react'),
+    classnames = require('classnames'),
     QueryLanguage = require('../../QueryLanguage'),
     QueryCompletion = require('../../QueryCompletion'),
     utils = require('../utils'),
@@ -118,7 +119,7 @@ var QueryBox = React.createClass({
   },
 
   render: function() {
-    var statusClasses = React.addons.classSet({
+    var statusClasses = classnames({
       'query-status': true,
       'good': this.state.errorMessage === null,
       'bad': this.state.errorMessage !== null,

--- a/cycledash/static/js/examine/components/QueryBox.js
+++ b/cycledash/static/js/examine/components/QueryBox.js
@@ -55,7 +55,7 @@ var QueryBox = React.createClass({
   },
   // Called when column names become available.
   initQueryBox: function() {
-    var $input = $(this.refs.input.getDOMNode());
+    var $input = $(this.refs.input);
     var handleChange = (e) => {
       this.parseAndUpdate($input.val());
     };
@@ -98,10 +98,10 @@ var QueryBox = React.createClass({
 
   // Update the CQL box to reflect this.props.query.
   setQueryBoxToQuery: function() {
-    if (document.activeElement == this.refs.input.getDOMNode()) {
+    if (document.activeElement == this.refs.input) {
       return;  // never change the text while the user is typing.
     }
-    var textBoxQuery = this.parseQuery(this.refs.input.getDOMNode().value);
+    var textBoxQuery = this.parseQuery(this.refs.input.value);
 
     // don't change the text box if its contents parse to the same thing.
     if (!QueryLanguage.isEquivalent(textBoxQuery, this.props.query)) {
@@ -114,7 +114,7 @@ var QueryBox = React.createClass({
    * This is factored out for easy intercepting while testing.
    */
   setDisplayedQuery: function(str) {
-    var $input = $(this.refs.input.getDOMNode());
+    var $input = $(this.refs.input);
     $input.typeahead('val', str);
   },
 

--- a/cycledash/static/js/examine/components/RecordsShown.js
+++ b/cycledash/static/js/examine/components/RecordsShown.js
@@ -1,7 +1,7 @@
 "use strict";
 
 var d3 = require('d3'),
-    React = require('react/addons');
+    React = require('react');
 
 var RecordsShown = React.createClass({
   propTypes: {

--- a/cycledash/static/js/examine/components/StatsSummary.js
+++ b/cycledash/static/js/examine/components/StatsSummary.js
@@ -2,7 +2,7 @@
 
 var _ = require('underscore'),
     d3 = require('d3'),
-    React = require('react/addons');
+    React = require('react');
 
 
 var StatsSummary = React.createClass({

--- a/cycledash/static/js/examine/components/VCFTable.js
+++ b/cycledash/static/js/examine/components/VCFTable.js
@@ -2,7 +2,7 @@
 
 var _ = require('underscore'),
     utils = require('../utils'),
-    React = require('react/addons'),
+    React = require('react'),
     classnames = require('classnames'),
     $ = require('jquery'),
     CommentBox = require('./CommentBox');
@@ -32,7 +32,7 @@ var VCFTable = React.createClass({
   scrollRecordToTop: function(record) {
     var idx = this.props.records.indexOf(record);
     if (idx >= 0) {
-      var row = $(this.refs.vcfTable.getDOMNode()).find('tr').get(idx);
+      var row = $(this.refs.vcfTable).find('tr').get(idx);
       $('html,body').animate({
         scrollTop: $(row).offset().top - 70
       }, 250 /* ms */);
@@ -239,7 +239,7 @@ var VCFTableBody = React.createClass({
     $(window).on('scroll.vcftable', () => {
       // Show more rows if the browser viewport is close to the bottom and
       // there are more rows to be shown.
-      var $table = $(this.refs.lazyload.getDOMNode()),
+      var $table = $(this.refs.lazyload),
           tableBottom = $table.position().top + $table.height(),
           windowBottom = $(window).scrollTop() + $(window).height();
       if (tableBottom < windowBottom + this.BOTTOM_BUFFER) {
@@ -250,7 +250,7 @@ var VCFTableBody = React.createClass({
   getInitialState: () => ({hasOpenedIGV: false}),
   componentWillUnmount: function() {
     $(window).off('scroll.vcftable');
-    $(this.refs.lazyload.getDOMNode()).off('click');
+    $(this.refs.lazyload).off('click');
   },
   render: function() {
     var selectedRecord = this.props.selectedRecord,

--- a/cycledash/static/js/examine/components/VCFTable.js
+++ b/cycledash/static/js/examine/components/VCFTable.js
@@ -3,6 +3,7 @@
 var _ = require('underscore'),
     utils = require('../utils'),
     React = require('react/addons'),
+    classnames = require('classnames'),
     $ = require('jquery'),
     CommentBox = require('./CommentBox');
 
@@ -82,7 +83,7 @@ var VCFTableHeader = React.createClass({
     var uberColumns = [],
         columnHeaders = [],
         posSorts = this.props.sortBys.filter(c => _.contains(['position', 'contig'], c.columnName)),
-        posSorterClasses = React.addons.classSet({
+        posSorterClasses = classnames({
           'sort': true,
           'desc': posSorts[0] && posSorts[0].order === 'desc',
           'asc': posSorts[0] && posSorts[0].order === 'asc',
@@ -170,7 +171,7 @@ var ColumnHeader = React.createClass({
       sortingBy = true;
       order = sortBy.order;
     }
-    var aClasses = React.addons.classSet({
+    var aClasses = classnames({
         'sorting-by': sortingBy,
         'desc': sortingBy && order === 'desc',
         'asc': sortingBy && order === 'asc',
@@ -321,7 +322,7 @@ var VCFRecord = React.createClass({
   render: function() {
     var hasComments = _.has(this.props.record, 'comments') &&
         this.props.record.comments.length > 0;
-    var commentBubbleClass = React.addons.classSet({
+    var commentBubbleClass = classnames({
       'comment-bubble': hasComments
     });
     var tds = [
@@ -368,7 +369,7 @@ var VCFRecord = React.createClass({
         );
       }
     });
-    var recordClasses = React.addons.classSet({selected: this.props.isSelected});
+    var recordClasses = classnames({selected: this.props.isSelected});
     return (
       <tr className={recordClasses} onClick={this.handleClick}>
         {tds}

--- a/cycledash/static/js/examine/components/types.js
+++ b/cycledash/static/js/examine/components/types.js
@@ -1,5 +1,5 @@
 'use strict';
-var React = require('react/addons');
+var React = require('react');
 
 
 // Sentinel value to indicate no chromosome restriction

--- a/cycledash/static/js/examine/examine.js
+++ b/cycledash/static/js/examine/examine.js
@@ -1,6 +1,7 @@
 "use strict";
 
 var React = require('react'),
+    ReactDOM = require('react-dom'),
     ExaminePage = require('./components/ExaminePage'),
     Dispatcher = require('./Dispatcher'),
     createRecordStore = require('./RecordStore'),
@@ -12,10 +13,10 @@ window.renderExaminePage = function(el, vcf, comparableVcfs,
   var dispatcher = new Dispatcher();
   var recordActions = getRecordActions(dispatcher);
   var recordStore = createRecordStore(vcf, igvHttpfsUrl, dispatcher);
-  React.render(<ExaminePage recordStore={recordStore}
-                            recordActions={recordActions}
-                            comparableVcfs={comparableVcfs}
-                            vcf={vcf}
-                            currentUser={currentUser}
-                            igvHttpfsUrl={igvHttpfsUrl} />, el);
+  ReactDOM.render(<ExaminePage recordStore={recordStore}
+                               recordActions={recordActions}
+                               comparableVcfs={comparableVcfs}
+                               vcf={vcf}
+                               currentUser={currentUser}
+                               igvHttpfsUrl={igvHttpfsUrl} />, el);
 };

--- a/cycledash/static/js/runs/components/RunsPage.js
+++ b/cycledash/static/js/runs/components/RunsPage.js
@@ -279,7 +279,7 @@ var RunRow = React.createClass({
     handleClick: React.PropTypes.func.isRequired
   },
   handleClick: function(evt) {
-    if (evt.target == this.refs.link.getDOMNode()) return;
+    if (evt.target == this.refs.link) return;
     this.props.handleClick();
   },
   render: function() {

--- a/cycledash/static/js/runs/components/forms.js
+++ b/cycledash/static/js/runs/components/forms.js
@@ -1,5 +1,6 @@
 'use strict';
 var React = require('react'),
+    classnames = require('classnames'),
     d3 = require('d3'),
     $ = require('jquery'),
     _ = require('underscore');
@@ -236,13 +237,15 @@ var TextInput = React.createClass({
       });
   },
   render: function() {
-    var formClasses = React.addons.classSet({
+    var formClasses = classnames({
       uploadable: this.props.uploadable,
       'receiving-drag': this.state.receivingDrag,
       'form-control': true
     });
-    var divClasses = React.addons.classSet({required: this.props.required,
-                                            'form-group add-form-input-full': true});
+    var divClasses = classnames({
+      required: this.props.required,
+      'form-group add-form-input-full': true
+    });
     return (
         <div className={divClasses}>
           <label className='control-label'>{this.props.label}</label>

--- a/cycledash/static/js/runs/components/forms.js
+++ b/cycledash/static/js/runs/components/forms.js
@@ -49,7 +49,7 @@ var NewRunForm = React.createClass({
     projectName: React.PropTypes.string.isRequired
   },
   componentDidMount: function() {
-    ajaxifyForm(this.refs.runForm.getDOMNode());
+    ajaxifyForm(this.refs.runForm);
   },
   render: function() {
     var props = this.props;
@@ -89,7 +89,7 @@ var NewBAMForm = React.createClass({
     projectName: React.PropTypes.string.isRequired
   },
   componentDidMount: function() {
-    ajaxifyForm(this.refs.bamForm.getDOMNode());
+    ajaxifyForm(this.refs.bamForm);
   },
   render: function() {
     return (
@@ -122,7 +122,7 @@ var NewBAMForm = React.createClass({
 
 var NewProjectForm = React.createClass({
   componentDidMount: function() {
-    ajaxifyForm(this.refs.projectForm.getDOMNode());
+    ajaxifyForm(this.refs.projectForm);
   },
   render: function() {
     return (
@@ -158,7 +158,7 @@ var TextInput = React.createClass({
     return {receivingDrag: false};
   },
   componentDidMount: function(prevProps, prevState) {
-    var $input = $(this.refs.input.getDOMNode());
+    var $input = $(this.refs.input);
     if (this.props.completions) {
       $input
         .typeahead({
@@ -199,7 +199,7 @@ var TextInput = React.createClass({
       if (files.length > 1) {
         window.alert('You may only upload one file at a time.');
       } else {
-        this._upload(files[0], this.refs.input.getDOMNode());
+        this._upload(files[0], this.refs.input);
       }
     }
   },

--- a/cycledash/static/js/runs/runs.js
+++ b/cycledash/static/js/runs/runs.js
@@ -1,9 +1,10 @@
 'use strict';
 var React = require('react'),
+    ReactDOM = require('react-dom'),
     RunsPage = require('./components/RunsPage');
 
 
 window.renderRunPage = function(el, projects, lastComments) {
-  React.render(<RunsPage projects={projects}
-                         comments={lastComments} />, el);
+  ReactDOM.render(<RunsPage projects={projects}
+                            comments={lastComments} />, el);
 };

--- a/cycledash/templates/examine.html
+++ b/cycledash/templates/examine.html
@@ -10,8 +10,6 @@
 {{ nav("examine", current_user) }}
 <div id="examine"></div>
 
-<script type="text/javascript" src="/static/lib/pileup.js/pileup.js"></script>
-
 <script type="text/javascript" src="/static/js/dist/bundled.js"></script>
 <script>
  window.renderExaminePage(document.getElementById('examine'),

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "homepage": "https://github.com/hammerlab/cycledash",
   "dependencies": {
     "bootstrap": "^3.2.0",
+    "classnames": "^2.2.0",
     "d3": "^3.4.11",
     "flux": "^2.0.1",
     "jquery": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "marked": "^0.3.2",
     "moment": "^2.9.0",
     "pileup": "^0.4.0",
-    "react": "^0.13.3",
+    "react": "^0.14.0",
     "underscore": "^1.7.0"
   },
   "devDependencies": {
@@ -44,6 +44,7 @@
     "mocha-lcov-reporter": "0.0.1",
     "pegjs": "^0.8.0",
     "process": "^0.9.0",
+    "react-dom": "^0.14.0",
     "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
     "sinon": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "moment": "^2.9.0",
     "pileup": "^0.4.0",
     "react": "^0.14.0",
+    "react-dom": "^0.14.0",
     "underscore": "^1.7.0"
   },
   "devDependencies": {
@@ -44,7 +45,7 @@
     "mocha-lcov-reporter": "0.0.1",
     "pegjs": "^0.8.0",
     "process": "^0.9.0",
-    "react-dom": "^0.14.0",
+    "react-addons-test-utils": "^0.14.0",
     "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
     "sinon": "1.13.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jquery": "2.1.1",
     "marked": "^0.3.2",
     "moment": "^2.9.0",
-    "pileup": "^0.4.0",
+    "pileup": "^0.5.0",
     "react": "^0.14.0",
     "react-dom": "^0.14.0",
     "underscore": "^1.7.0"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "marked": "^0.3.2",
     "moment": "^2.9.0",
     "pileup": "^0.4.0",
-    "react": "^0.12.2",
+    "react": "^0.13.3",
     "underscore": "^1.7.0"
   },
   "devDependencies": {
@@ -33,7 +33,7 @@
     "gulp-ext-replace": "^0.2.0",
     "gulp-livereload": "^2.1.1",
     "gulp-peg": "^0.1.2",
-    "gulp-react": "^1.0.1",
+    "gulp-react": "^3.1.0",
     "gulp-sass": "^2.0.1",
     "jsdom": "^1.0.3",
     "jsxhint": "^0.7.0",
@@ -43,7 +43,7 @@
     "mocha-lcov-reporter": "0.0.1",
     "pegjs": "^0.8.0",
     "process": "^0.9.0",
-    "react-tools": "^0.12.1",
+    "react-tools": "^0.13.3",
     "reactify": "^1.1.1",
     "sinon": "1.13.0",
     "typeahead.js": "^0.10.5",

--- a/tests/js/ExaminePage-comments-test.js
+++ b/tests/js/ExaminePage-comments-test.js
@@ -1,7 +1,8 @@
 'use strict';
 
 require('./testdom')('<html><body></body></html>');
-var React = require('react/addons'),
+var React = require('react'),
+    TestUtils = require('react-addons-test-utils'),
     assert = require('assert'),
     _ = require('underscore'),
     sinon = require('sinon');
@@ -11,7 +12,6 @@ var ExaminePage = require('../../cycledash/static/js/examine/components/ExamineP
     createRecordStore = require('../../cycledash/static/js/examine/RecordStore'),
     RecordActions = require('../../cycledash/static/js/examine/RecordActions'),
     Dispatcher = require('../../cycledash/static/js/examine/Dispatcher'),
-    TestUtils = React.addons.TestUtils,
     Utils = require('./Utils'),
     CommentUtils = require('./CommentUtils');
 

--- a/tests/js/ExaminePage-comments-test.js
+++ b/tests/js/ExaminePage-comments-test.js
@@ -194,6 +194,7 @@ describe('ExaminePage Comments', function() {
   });
 
   it('should undo actions when server fails', function() {
+    this.timeout(5000);
     examine = renderExamine({
       'PUT': ['/api/runs/1/comments/17'],
       'POST': ['/api/runs/1/comments'],

--- a/tests/js/ExaminePage-test.js
+++ b/tests/js/ExaminePage-test.js
@@ -2,7 +2,8 @@
 'use strict';
 
 require('./testdom')('<html><body></body></html>');
-var React = require('react/addons'),
+var React = require('react'),
+    TestUtils = require('react-addons-test-utils'),
     assert = require('assert'),
     _ = require('underscore');
 
@@ -12,7 +13,6 @@ var ExaminePage = require('../../cycledash/static/js/examine/components/ExamineP
     createRecordStore = require('../../cycledash/static/js/examine/RecordStore'),
     RecordActions = require('../../cycledash/static/js/examine/RecordActions'),
     Dispatcher = require('../../cycledash/static/js/examine/Dispatcher'),
-    TestUtils = React.addons.TestUtils,
     Utils = require('./Utils'),
     DataUtils = require('./DataUtils');
 

--- a/tests/js/IGVLink-test.js
+++ b/tests/js/IGVLink-test.js
@@ -5,12 +5,12 @@
 'use strict';
 
 require('./testdom')('<html><body></body></html>');
-var React = require('react/addons'),
+var React = require('react'),
+    TestUtils = require('react-addons-test-utils'),
     assert = require('assert'),
     _ = require('underscore');
 
 var CommentBox = require('../../cycledash/static/js/examine/components/CommentBox'),
-    TestUtils = React.addons.TestUtils,
     Utils = require('./Utils'),
     DataUtils = require('./DataUtils');
 

--- a/tests/js/Utils-test.js
+++ b/tests/js/Utils-test.js
@@ -3,8 +3,7 @@
 require('./testdom')('<html><body></body></html>');
 var Utils = require('./Utils'),
     assert = require('assert'),
-    React = require('react'),
-    TestUtils = require('react-addons-test-utils');
+    React = require('react');
 
 describe('Utils', function() {
   describe('makeObj', function() {

--- a/tests/js/Utils-test.js
+++ b/tests/js/Utils-test.js
@@ -3,7 +3,8 @@
 require('./testdom')('<html><body></body></html>');
 var Utils = require('./Utils'),
     assert = require('assert'),
-    React = require('react/addons');
+    React = require('react'),
+    TestUtils = require('react-addons-test-utils');
 
 describe('Utils', function() {
   describe('makeObj', function() {
@@ -21,7 +22,7 @@ describe('Utils', function() {
 
   describe('stubReactMethod', function() {
     it('should stub a React class method, then restore it', function() {
-      var TestUtils = React.addons.TestUtils;
+      var TestUtils = require('react-addons-test-utils');
       var captured = [];
       var RC = React.createClass({
         render: function() {

--- a/tests/js/Utils.js
+++ b/tests/js/Utils.js
@@ -11,7 +11,7 @@ var _ = require('underscore'),
  * Apply a CSS selector to a React tree. Returns an array of DOM nodes.
  */
 function findInComponent(selector, component) {
-  return _.toArray(component.getDOMNode().querySelectorAll(selector));
+  return _.toArray(component.querySelectorAll(selector));
 }
 
 /**

--- a/tests/js/Utils.js
+++ b/tests/js/Utils.js
@@ -11,7 +11,7 @@ var _ = require('underscore'),
  * Apply a CSS selector to a React tree. Returns an array of DOM nodes.
  */
 function findInComponent(selector, component) {
-  return _.toArray(component.querySelectorAll(selector));
+  return _.toArray(component.getDOMNode().querySelectorAll(selector));
 }
 
 /**
@@ -19,7 +19,7 @@ function findInComponent(selector, component) {
  * Returns the Sinon stub. Don't forget to call .restore() on it!
  */
 function stubReactMethod(ReactClass, method, fn) {
-  return sinon.stub(ReactClass.type.prototype.__reactAutoBindMap, method, fn);
+  return sinon.stub(ReactClass.prototype.__reactAutoBindMap, method, fn);
 }
 
 function makeObj(list, keyValFn) {


### PR DESCRIPTION
Highlights:
- `React` → `ReactDOM`
- Drop many `.getDOMNode()` calls
- `React.addons.classSet` → `require('classnames')`
- `React.addons.TestUtils` → `require('react-addons-test-utils')`
- `ReactClass.type` → `ReactClass`
- Updated to `pileup@0.5.1`

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/hammerlab/cycledash/858)

<!-- Reviewable:end -->
